### PR TITLE
Feature/close application rpc

### DIFF
--- a/src/appMain/sdl_preloaded_pt.json
+++ b/src/appMain/sdl_preloaded_pt.json
@@ -58,6 +58,12 @@
                         "LIMITED",
                         "NONE"]
                     },
+                    "CloseApplication": {
+                        "hmi_levels": ["BACKGROUND",
+                        "FULL",
+                        "LIMITED",
+                        "NONE"]
+                    },
                     "CreateInteractionChoiceSet": {
                         "hmi_levels": ["BACKGROUND",
                         "FULL",

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/close_application_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/close_application_request.h
@@ -1,0 +1,102 @@
+/*
+
+ Copyright (c) 2018, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_CLOSE_APPLICATION_REQUEST_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_CLOSE_APPLICATION_REQUEST_H_
+
+#include <cstdint>
+
+#include "application_manager/commands/command_request_impl.h"
+#include "application_manager/event_engine/event_observer.h"
+#include "utils/macro.h"
+
+namespace sdl_rpc_plugin {
+namespace app_mngr = application_manager;
+
+namespace commands {
+
+/**
+  * @brief CloseApplicationRequest command class
+  */
+class CloseApplicationRequest : public app_mngr::commands::CommandRequestImpl {
+ public:
+  /**
+    * @brief CloseApplicationRequest class constructor
+    *
+    * @param message Incoming SmartObject message
+    */
+  CloseApplicationRequest(const app_mngr::commands::MessageSharedPtr& message,
+                          app_mngr::ApplicationManager& application_manager,
+                          app_mngr::rpc_service::RPCService& rpc_service,
+                          app_mngr::HMICapabilities& hmi_capabilities,
+                          policy::PolicyHandlerInterface& policy_handler);
+  /**
+    * @brief CloseApplicationRequest class destructor
+    */
+  ~CloseApplicationRequest() FINAL;
+
+  /**
+    * @brief Execute command
+    */
+  void Run() FINAL;
+
+  /**
+    * @brief Interface method that is called whenever new event received
+    *
+    * @param event The received event
+    */
+  void on_event(const app_mngr::event_engine::Event& event) FINAL;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(CloseApplicationRequest);
+
+  /**
+    * @brief Send Basic Communication Request to HMI.
+    *
+    * @param app - Application which have to set specified HMI level.
+    * @param hmi_level - New HMI level for specified application.
+    * @param send_policy_priority - Defines whether to send "priority" field
+    * with request
+    * @param activate_app_corr_id - Variable for detting ActivateAppRequest
+    * correlation id.
+    * @return - True if command is executed, otherwise return false.
+    */
+  bool SendBCActivateApp(app_mngr::ApplicationConstSharedPtr app,
+                         const hmi_apis::Common_HMILevel::eType hmi_level,
+                         const bool send_policy_priority);
+};
+
+}  // namespace commands
+}  // namespace sdl_rpc_plugin
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_CLOSE_APPLICATION_REQUEST_H_

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/close_application_request.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/close_application_request.h
@@ -53,7 +53,11 @@ class CloseApplicationRequest : public app_mngr::commands::CommandRequestImpl {
   /**
     * @brief CloseApplicationRequest class constructor
     *
-    * @param message Incoming SmartObject message
+    * @param message - Incoming SmartObject message
+    * @param application_manager - reference to ApplicationManager instance.
+    * @param rpc_service - reference to RPCService instance.
+    * @param hmi_capabilities - reference to HMICapabilities instance.
+    * @param policy_handler - reference to PolicyHandlerInterface instance.
     */
   CloseApplicationRequest(const app_mngr::commands::MessageSharedPtr& message,
                           app_mngr::ApplicationManager& application_manager,
@@ -78,10 +82,8 @@ class CloseApplicationRequest : public app_mngr::commands::CommandRequestImpl {
   void on_event(const app_mngr::event_engine::Event& event) FINAL;
 
  private:
-  DISALLOW_COPY_AND_ASSIGN(CloseApplicationRequest);
-
   /**
-    * @brief Send Basic Communication Request to HMI.
+    * @brief Sends ActivateApp request to HMI.
     *
     * @param app - Application which have to set specified HMI level.
     * @param hmi_level - New HMI level for specified application.
@@ -94,6 +96,8 @@ class CloseApplicationRequest : public app_mngr::commands::CommandRequestImpl {
   bool SendBCActivateApp(app_mngr::ApplicationConstSharedPtr app,
                          const hmi_apis::Common_HMILevel::eType hmi_level,
                          const bool send_policy_priority);
+
+  DISALLOW_COPY_AND_ASSIGN(CloseApplicationRequest);
 };
 
 }  // namespace commands

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/close_application_response.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/close_application_response.h
@@ -1,0 +1,79 @@
+/*
+
+ Copyright (c) 2018, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_CLOSE_APPLICATION_RESPONSE_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_CLOSE_APPLICATION_RESPONSE_H_
+
+#include "application_manager/commands/command_response_impl.h"
+#include "utils/macro.h"
+
+namespace sdl_rpc_plugin {
+namespace app_mngr = application_manager;
+
+namespace commands {
+
+/**
+ * @brief CloseApplicationResponse command class
+ **/
+class CloseApplicationResponse
+    : public app_mngr::commands::CommandResponseImpl {
+ public:
+  /**
+   * @brief CloseApplicationResponse class constructor
+   *
+   * @param message - Incoming SmartObject message
+   **/
+  CloseApplicationResponse(const app_mngr::commands::MessageSharedPtr& message,
+                           app_mngr::ApplicationManager& application_manager,
+                           app_mngr::rpc_service::RPCService& rpc_service,
+                           app_mngr::HMICapabilities& hmi_capabilities,
+                           policy::PolicyHandlerInterface& policy_handler);
+
+  /**
+   * @brief CloseApplicationResponse class destructor
+   **/
+  ~CloseApplicationResponse() FINAL;
+
+  /**
+   * @brief Execute command
+   **/
+  void Run() FINAL;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(CloseApplicationResponse);
+};
+
+}  // namespace commands
+}  // namespace sdl_rpc_plugin
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_MOBILE_CLOSE_APPLICATION_RESPONSE_H_

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/close_application_response.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/mobile/close_application_response.h
@@ -52,6 +52,10 @@ class CloseApplicationResponse
    * @brief CloseApplicationResponse class constructor
    *
    * @param message - Incoming SmartObject message
+   * @param application_manager - reference to ApplicationManager instance.
+   * @param rpc_service - reference to RPCService instance.
+   * @param hmi_capabilities - reference to HMICapabilities instance.
+   * @param policy_handler - reference to PolicyHandlerInterface instance.
    **/
   CloseApplicationResponse(const app_mngr::commands::MessageSharedPtr& message,
                            app_mngr::ApplicationManager& application_manager,

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/close_application_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/close_application_request.cc
@@ -1,0 +1,155 @@
+/*
+
+ Copyright (c) 2018, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sdl_rpc_plugin/commands/mobile/close_application_request.h"
+#include "application_manager/rpc_service.h"
+#include "application_manager/message_helper.h"
+#include "utils/include/utils/helpers.h"
+
+namespace sdl_rpc_plugin {
+using namespace application_manager;
+
+namespace commands {
+
+CloseApplicationRequest::CloseApplicationRequest(
+    const app_mngr::commands::MessageSharedPtr& message,
+    app_mngr::ApplicationManager& application_manager,
+    app_mngr::rpc_service::RPCService& rpc_service,
+    app_mngr::HMICapabilities& hmi_capabilities,
+    policy::PolicyHandlerInterface& policy_handler)
+    : CommandRequestImpl(message,
+                         application_manager,
+                         rpc_service,
+                         hmi_capabilities,
+                         policy_handler) {}
+
+CloseApplicationRequest::~CloseApplicationRequest() {}
+
+void CloseApplicationRequest::Run() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  auto application = application_manager_.application(connection_key());
+
+  if (!application) {
+    LOG4CXX_ERROR(logger_, "No such application registered.");
+    SendResponse(false, mobile_apis::Result::APPLICATION_NOT_REGISTERED);
+    return;
+  }
+
+  const auto app_hmi_level = application->hmi_level();
+
+  if (mobile_apis::HMILevel::HMI_NONE == app_hmi_level) {
+    LOG4CXX_DEBUG(logger_,
+                  "Application with id " << connection_key()
+                                         << " is already in hmi_level NONE.");
+    SendResponse(false, mobile_apis::Result::IGNORED);
+    return;
+  }
+
+  const bool sent_success =
+      SendBCActivateApp(application, hmi_apis::Common_HMILevel::NONE, true);
+
+  if (!sent_success) {
+    LOG4CXX_ERROR(logger_, "Unable to send BC.ActivateApp");
+    SendResponse(false, mobile_apis::Result::INVALID_DATA);
+  }
+}
+
+void CloseApplicationRequest::on_event(const event_engine::Event& event) {
+  using namespace helpers;
+  LOG4CXX_AUTO_TRACE(logger_);
+  const auto message = event.smart_object();
+
+  if (hmi_apis::FunctionID::BasicCommunication_ActivateApp != event.id()) {
+    LOG4CXX_ERROR(logger_, "Received unknown event" << event.id());
+    return;
+  }
+
+  const auto hmi_result = static_cast<hmi_apis::Common_Result::eType>(
+      message[strings::params][hmi_response::code].asInt());
+
+  const auto mobile_result = MessageHelper::HMIToMobileResult(hmi_result);
+  const bool success = Compare<hmi_apis::Common_Result::eType, EQ, ONE>(
+      hmi_result,
+      hmi_apis::Common_Result::SUCCESS,
+      hmi_apis::Common_Result::WARNINGS);
+
+  if (success) {
+    auto application = application_manager_.application(connection_key());
+    if (!application) {
+      LOG4CXX_DEBUG(logger_, "No such application registered");
+      SendResponse(false, mobile_apis::Result::INVALID_DATA);
+      return;
+    }
+    application->set_hmi_level(mobile_apis::HMILevel::HMI_NONE);
+    LOG4CXX_DEBUG(logger_,
+                  "Application with id " << application->app_id()
+                                         << " has switched to HMI_level NONE.");
+  } else {
+    LOG4CXX_WARN(logger_, "Application hasn't switched to HMI_level NONE.");
+  }
+  SendResponse(success, mobile_result);
+}
+
+bool CloseApplicationRequest::SendBCActivateApp(
+    ApplicationConstSharedPtr app,
+    const hmi_apis::Common_HMILevel::eType hmi_level,
+    const bool send_policy_priority) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  auto bc_activate_app_request = MessageHelper::GetBCActivateAppRequestToHMI(
+      app,
+      application_manager_.connection_handler().get_session_observer(),
+      application_manager_.GetPolicyHandler(),
+      hmi_level,
+      send_policy_priority,
+      application_manager_);
+  if (!bc_activate_app_request) {
+    LOG4CXX_ERROR(logger_, "Unable to create BC.ActivateAppRequest");
+    return false;
+  }
+
+  if (!application_manager_.GetRPCService().ManageHMICommand(
+          bc_activate_app_request)) {
+    LOG4CXX_ERROR(logger_, "Unable to send BC.ActivateAppRequest");
+    return false;
+  }
+  const auto activate_app_corr_id =
+      (*bc_activate_app_request)[strings::params][strings::correlation_id]
+          .asUInt();
+  subscribe_on_event(hmi_apis::FunctionID::BasicCommunication_ActivateApp,
+                     activate_app_corr_id);
+  return true;
+}
+
+}  // namespace commands
+}  // namespace sdl_rpc_plugin

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/close_application_request.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/close_application_request.cc
@@ -76,10 +76,10 @@ void CloseApplicationRequest::Run() {
     return;
   }
 
-  const bool sent_success =
+  const bool sending_result =
       SendBCActivateApp(application, hmi_apis::Common_HMILevel::NONE, true);
 
-  if (!sent_success) {
+  if (!sending_result) {
     LOG4CXX_ERROR(logger_, "Unable to send BC.ActivateApp");
     SendResponse(false, mobile_apis::Result::INVALID_DATA);
   }
@@ -88,13 +88,13 @@ void CloseApplicationRequest::Run() {
 void CloseApplicationRequest::on_event(const event_engine::Event& event) {
   using namespace helpers;
   LOG4CXX_AUTO_TRACE(logger_);
-  const auto message = event.smart_object();
 
   if (hmi_apis::FunctionID::BasicCommunication_ActivateApp != event.id()) {
     LOG4CXX_ERROR(logger_, "Received unknown event" << event.id());
     return;
   }
 
+  const auto message = event.smart_object();
   const auto hmi_result = static_cast<hmi_apis::Common_Result::eType>(
       message[strings::params][hmi_response::code].asInt());
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/close_application_response.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/mobile/close_application_response.cc
@@ -1,0 +1,61 @@
+/*
+ Copyright (c) 2018, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sdl_rpc_plugin/commands/mobile/close_application_response.h"
+#include "application_manager/commands/command_response_impl.h"
+
+namespace sdl_rpc_plugin {
+using namespace application_manager;
+namespace commands {
+
+CloseApplicationResponse::CloseApplicationResponse(
+    const application_manager::commands::MessageSharedPtr& message,
+    ApplicationManager& application_manager,
+    rpc_service::RPCService& rpc_service,
+    HMICapabilities& hmi_capabilities,
+    policy::PolicyHandlerInterface& policy_handler)
+    : CommandResponseImpl(message,
+                          application_manager,
+                          rpc_service,
+                          hmi_capabilities,
+                          policy_handler) {}
+
+CloseApplicationResponse::~CloseApplicationResponse() {}
+
+void CloseApplicationResponse::Run() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  rpc_service_.SendMessageToMobile(message_);
+}
+
+}  // commands
+}  // sdl_rpc_plugins

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/mobile_command_factory.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/mobile_command_factory.cc
@@ -124,6 +124,8 @@
 #include "sdl_rpc_plugin/commands/mobile/dial_number_response.h"
 #include "sdl_rpc_plugin/commands/mobile/send_haptic_data_request.h"
 #include "sdl_rpc_plugin/commands/mobile/send_haptic_data_response.h"
+#include "sdl_rpc_plugin/commands/mobile/close_application_request.h"
+#include "sdl_rpc_plugin/commands/mobile/close_application_response.h"
 #include "interfaces/MOBILE_API.h"
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "ApplicationManager")
@@ -396,6 +398,12 @@ CommandCreator& MobileCommandFactory::get_creator_factory(
       using app_mngr::commands::Command;
       return factory.GetCreator<commands::GenericResponse>();
     }
+    case mobile_apis::FunctionID::CloseApplicationID: {
+      using app_mngr::commands::Command;
+      return Command::CommandSource::SOURCE_MOBILE == source
+                 ? factory.GetCreator<commands::CloseApplicationRequest>()
+                 : factory.GetCreator<commands::CloseApplicationResponse>();
+    } break;
     default: { return factory.GetCreator<InvalidCommand>(); }
   }
 }

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/close_application_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/close_application_request_test.cc
@@ -155,8 +155,9 @@ class CloseApplicationRequestTest
   CloseApplicationCommandPtr command_;
 };
 
-TEST_F(CloseApplicationRequestTest,
-       CloseApplicationRequestSendsResponse_APPLICATION_NOT_REGISTERED) {
+TEST_F(
+    CloseApplicationRequestTest,
+    CloseApplicationRequest_SendsNegativeResponse_APPLICATION_NOT_REGISTERED) {
   using namespace am;
   auto message = CreateCloseAppMessage();
 
@@ -180,7 +181,7 @@ TEST_F(CloseApplicationRequestTest,
 }
 
 TEST_F(CloseApplicationRequestTest,
-       CloseApplicationRequestSendsResponse_IGNORED) {
+       CloseApplicationRequest_SendsNegativeResponse_IGNORED) {
   using namespace am;
   auto message = CreateCloseAppMessage();
 
@@ -206,7 +207,7 @@ TEST_F(CloseApplicationRequestTest,
 }
 
 TEST_F(CloseApplicationRequestTest,
-       CloseApplicationRequestSendsResponse_INVALID_DATA) {
+       CloseApplicationRequest_SendsNegativeResponse_INVALID_DATA) {
   using namespace am;
   CloseApplicationCommandPtr command(
       CreateCommand<sdl_rpc_plugin::commands::CloseApplicationRequest>(
@@ -225,7 +226,7 @@ TEST_F(CloseApplicationRequestTest,
 }
 
 TEST_F(CloseApplicationRequestTest,
-       CloseApplicationRequestSendsResponse_GENERIC_ERROR) {
+       CloseApplicationRequest_SendsNegativeResponse_GENERIC_ERROR) {
   using namespace am;
 
   CloseApplicationCommandPtr command(
@@ -254,7 +255,7 @@ TEST_F(CloseApplicationRequestTest,
 }
 
 TEST_F(CloseApplicationRequestTest,
-       CloseApplicationRequest_OnEvent_Success_INVALID_DATA) {
+       CloseApplicationRequest_OnEvent_SuccessResult_INVALID_DATA) {
   using namespace am;
 
   CloseApplicationCommandPtr command(
@@ -278,7 +279,7 @@ TEST_F(CloseApplicationRequestTest,
 }
 
 TEST_F(CloseApplicationRequestTest,
-       CloseApplicationRequest_OnEvent_Success_Result_SUCCESS) {
+       CloseApplicationRequest_OnEvent_SuccessResult_SUCCESS) {
   using namespace am;
 
   CloseApplicationCommandPtr command(

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/close_application_request_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/close_application_request_test.cc
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) 2018, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <memory>
+#include <string>
+#include <cstdint>
+
+#include "mobile/close_application_request.h"
+
+#include "gtest/gtest.h"
+
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/command_request_test.h"
+#include "application_manager/mock_application_manager.h"
+#include "application_manager/mock_application.h"
+#include "application_manager/mock_rpc_service.h"
+#include "connection_handler/mock_connection_handler.h"
+#include "protocol_handler/mock_session_observer.h"
+#include "utils/macro.h"
+
+namespace test {
+namespace components {
+namespace commands_test {
+namespace mobile_commands_test {
+namespace close_application_request {
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::ReturnRef;
+using am::commands::MessageSharedPtr;
+namespace am = ::application_manager;
+
+typedef std::shared_ptr<sdl_rpc_plugin::commands::CloseApplicationRequest>
+    CloseApplicationCommandPtr;
+
+namespace {
+const uint32_t kConnectionKey = 2u;
+const uint32_t kCorrelationId = 3u;
+}
+
+MessageSharedPtr CreateCloseAppMessage() {
+  using namespace am;
+  auto message = std::make_shared<SmartObject>(smart_objects::SmartType_Null);
+  auto& params = (*message)[strings::params];
+  params[strings::connection_key] = kConnectionKey;
+  params[strings::function_id] = mobile_apis::FunctionID::CloseApplicationID;
+  return message;
+}
+
+class CloseApplicationRequestTest
+    : public CommandRequestTest<CommandsTestMocks::kIsNice> {
+ public:
+  CloseApplicationRequestTest()
+      : mock_app_(CreateMockApp())
+      , message_(CreateCloseAppMessage())
+      , response_message_(CreateMessage()) {}
+
+  void DeffaultRequestRunCheck(const bool success_send_to_hmi) {
+    EXPECT_CALL(app_mngr_, application(kConnectionKey))
+        .WillOnce(Return(mock_app_));
+    EXPECT_CALL(*mock_app_, hmi_level())
+        .WillOnce(Return(mobile_apis::HMILevel::eType::HMI_FULL));
+
+    ON_CALL(*am::MockMessageHelper::message_helper_mock(),
+            GetBCActivateAppRequestToHMI(_, _, _, _, _, _))
+        .WillByDefault(Return(
+            std::make_shared<SmartObject>(smart_objects::SmartType_Null)));
+
+    EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_))
+        .WillOnce(Return(success_send_to_hmi));
+  }
+
+  void SDLRecivesEventMessage(MessageSharedPtr& event_msg,
+                              hmi_apis::Common_Result::eType event_result_code,
+                              const bool is_app_exists) {
+    (*event_msg)[am::strings::params][am::hmi_response::code] =
+        event_result_code;
+
+    EXPECT_CALL(app_mngr_, application(kConnectionKey))
+        .WillOnce(Return(is_app_exists ? mock_app_ : MockAppPtr()));
+
+    EXPECT_CALL(mock_rpc_service_,
+                ManageMobileCommand(
+                    _, am::commands::Command::CommandSource::SOURCE_SDL))
+        .WillOnce(DoAll(SaveArg<0>(&response_message_), Return(true)));
+  }
+
+  void CheckResponseParameters(const bool is_success,
+                               const mobile_apis::Result::eType result_code) {
+    using namespace am;
+    const auto message_result_code = static_cast<mobile_apis::Result::eType>(
+        (*response_message_)[strings::msg_params][strings::result_code]
+            .asInt());
+    EXPECT_EQ(message_result_code, result_code);
+
+    const bool message_success =
+        (*response_message_)[strings::msg_params][strings::success].asBool();
+    EXPECT_EQ(message_success, is_success);
+  }
+
+ protected:
+  void SetUp() OVERRIDE {
+    using namespace am;
+    ON_CALL(app_mngr_, application(kConnectionKey))
+        .WillByDefault(Return(mock_app_));
+    ON_CALL(app_mngr_, GetRPCService())
+        .WillByDefault(ReturnRef(mock_rpc_service_));
+    ON_CALL(app_mngr_, GetNextHMICorrelationID())
+        .WillByDefault(Return(kCorrelationId + 1));
+    ON_CALL(app_mngr_, GetPolicyHandler())
+        .WillByDefault(ReturnRef(mock_policy_handler_));
+    ON_CALL(app_mngr_, connection_handler())
+        .WillByDefault(ReturnRef(mock_connection_handler_));
+    ON_CALL(mock_connection_handler_, get_session_observer())
+        .WillByDefault(ReturnRef(mock_session_handler_));
+    ON_CALL(*mock_app_, app_id()).WillByDefault(Return(kConnectionKey));
+  }
+
+  MockAppPtr mock_app_;
+  MessageSharedPtr message_;
+  MessageSharedPtr response_message_;
+  NiceMock<components::connection_handler_test::MockConnectionHandler>
+      mock_connection_handler_;
+  components::protocol_handler_test::MockSessionObserver mock_session_handler_;
+  CloseApplicationCommandPtr command_;
+};
+
+TEST_F(CloseApplicationRequestTest,
+       CloseApplicationRequestSendsResponse_APPLICATION_NOT_REGISTERED) {
+  using namespace am;
+  auto message = CreateCloseAppMessage();
+
+  CloseApplicationCommandPtr command(
+      CreateCommand<sdl_rpc_plugin::commands::CloseApplicationRequest>(
+          message));
+
+  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+      .WillOnce(Return(MockAppPtr()));
+
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_)).Times(0);
+
+  EXPECT_CALL(
+      mock_rpc_service_,
+      ManageMobileCommand(_, am::commands::Command::CommandSource::SOURCE_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&response_message_), Return(true)));
+  command->Run();
+
+  CheckResponseParameters(false,
+                          mobile_apis::Result::APPLICATION_NOT_REGISTERED);
+}
+
+TEST_F(CloseApplicationRequestTest,
+       CloseApplicationRequestSendsResponse_IGNORED) {
+  using namespace am;
+  auto message = CreateCloseAppMessage();
+
+  CloseApplicationCommandPtr command(
+      CreateCommand<sdl_rpc_plugin::commands::CloseApplicationRequest>(
+          message_));
+  MockAppPtr mock_app(CreateMockApp());
+
+  EXPECT_CALL(app_mngr_, application(kConnectionKey))
+      .WillOnce(Return(mock_app));
+  EXPECT_CALL(*mock_app, hmi_level())
+      .WillOnce(Return(mobile_apis::HMILevel::eType::HMI_NONE));
+
+  EXPECT_CALL(mock_rpc_service_, ManageHMICommand(_)).Times(0);
+
+  EXPECT_CALL(
+      mock_rpc_service_,
+      ManageMobileCommand(_, am::commands::Command::CommandSource::SOURCE_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&response_message_), Return(true)));
+  command->Run();
+
+  CheckResponseParameters(false, mobile_apis::Result::IGNORED);
+}
+
+TEST_F(CloseApplicationRequestTest,
+       CloseApplicationRequestSendsResponse_INVALID_DATA) {
+  using namespace am;
+  CloseApplicationCommandPtr command(
+      CreateCommand<sdl_rpc_plugin::commands::CloseApplicationRequest>(
+          message_));
+
+  DeffaultRequestRunCheck(false);
+
+  EXPECT_CALL(
+      mock_rpc_service_,
+      ManageMobileCommand(_, am::commands::Command::CommandSource::SOURCE_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&response_message_), Return(true)));
+
+  command->Run();
+
+  CheckResponseParameters(false, mobile_apis::Result::INVALID_DATA);
+}
+
+TEST_F(CloseApplicationRequestTest,
+       CloseApplicationRequestSendsResponse_GENERIC_ERROR) {
+  using namespace am;
+
+  CloseApplicationCommandPtr command(
+      CreateCommand<sdl_rpc_plugin::commands::CloseApplicationRequest>(
+          message_));
+
+  DeffaultRequestRunCheck(true);
+
+  command->Run();
+
+  auto negative_response = CreateMessage();
+  (*negative_response)[strings::msg_params][strings::result_code] =
+      mobile_apis::Result::GENERIC_ERROR;
+  ON_CALL(*am::MockMessageHelper::message_helper_mock(),
+          CreateNegativeResponse(_, _, _, mobile_apis::Result::GENERIC_ERROR))
+      .WillByDefault(Return(negative_response));
+
+  EXPECT_CALL(
+      mock_rpc_service_,
+      ManageMobileCommand(_, am::commands::Command::CommandSource::SOURCE_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&response_message_), Return(true)));
+
+  command->onTimeOut();
+
+  CheckResponseParameters(false, mobile_apis::Result::GENERIC_ERROR);
+}
+
+TEST_F(CloseApplicationRequestTest,
+       CloseApplicationRequest_OnEvent_Success_INVALID_DATA) {
+  using namespace am;
+
+  CloseApplicationCommandPtr command(
+      CreateCommand<sdl_rpc_plugin::commands::CloseApplicationRequest>(
+          message_));
+
+  DeffaultRequestRunCheck(true);
+
+  command->Run();
+
+  MessageSharedPtr event_msg(CreateMessage(smart_objects::SmartType_Map));
+
+  SDLRecivesEventMessage(event_msg, hmi_apis::Common_Result::SUCCESS, false);
+
+  Event event(hmi_apis::FunctionID::BasicCommunication_ActivateApp);
+  event.set_smart_object(*event_msg);
+
+  command->on_event(event);
+
+  CheckResponseParameters(false, mobile_apis::Result::INVALID_DATA);
+}
+
+TEST_F(CloseApplicationRequestTest,
+       CloseApplicationRequest_OnEvent_Success_Result_SUCCESS) {
+  using namespace am;
+
+  CloseApplicationCommandPtr command(
+      CreateCommand<sdl_rpc_plugin::commands::CloseApplicationRequest>(
+          message_));
+
+  DeffaultRequestRunCheck(true);
+
+  command->Run();
+
+  MessageSharedPtr event_msg(CreateMessage(smart_objects::SmartType_Map));
+
+  SDLRecivesEventMessage(event_msg, hmi_apis::Common_Result::SUCCESS, true);
+
+  Event event(hmi_apis::FunctionID::BasicCommunication_ActivateApp);
+  event.set_smart_object(*event_msg);
+
+  command->on_event(event);
+
+  CheckResponseParameters(true, mobile_apis::Result::SUCCESS);
+}
+
+}  // close_application_request
+}  // mobile_commands_test
+}  // commands_test
+}  // components
+}  // test

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/close_application_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/mobile/close_application_response_test.cc
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2018, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <memory>
+
+#include "mobile/close_application_response.h"
+#include "mobile/close_application_request.h"
+
+#include "gtest/gtest.h"
+
+#include "smart_objects/smart_object.h"
+#include "application_manager/smart_object_keys.h"
+#include "application_manager/commands/commands_test.h"
+#include "application_manager/mock_event_dispatcher.h"
+
+namespace test {
+namespace components {
+namespace command_test {
+namespace mobile_command_test {
+namespace close_application_response {
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::SaveArg;
+using ::testing::DoAll;
+using am::commands::MessageSharedPtr;
+namespace am = ::application_manager;
+
+typedef std::shared_ptr<sdl_rpc_plugin::commands::CloseApplicationResponse>
+    CloseApplicationCommandPtr;
+
+namespace {
+const uint32_t kConnectionKey = 1u;
+const uint32_t kCorrelationId = 2u;
+}
+
+MessageSharedPtr CreateCloseAppMessage() {
+  using namespace am;
+  auto message = std::make_shared<smart_objects::SmartObject>(
+      smart_objects::SmartType_Null);
+  auto& params = (*message)[strings::params];
+  params[strings::connection_key] = kConnectionKey;
+  params[strings::function_id] = mobile_apis::FunctionID::CloseApplicationID;
+  return message;
+}
+
+class CloseApplicationResponseTest
+    : public commands_test::CommandsTest<
+          commands_test::CommandsTestMocks::kIsNice> {
+ public:
+  CloseApplicationResponseTest()
+      : message_(CreateCloseAppMessage())
+      , command_(
+            CreateCommand<sdl_rpc_plugin::commands::CloseApplicationResponse>(
+                message_)) {}
+
+  MessageSharedPtr message_;
+  CloseApplicationCommandPtr command_;
+};
+
+TEST_F(CloseApplicationResponseTest, CloseApplicationResponse_SUCCESS) {
+  using namespace am;
+  using namespace mobile_apis;
+
+  (*message_)[strings::msg_params][strings::result_code] = Result::SUCCESS;
+  (*message_)[strings::msg_params][strings::success] = true;
+
+  MessageSharedPtr response_message(CreateMessage());
+
+  EXPECT_CALL(mock_rpc_service_, SendMessageToMobile(_, _))
+      .WillOnce(SaveArg<0>(&response_message));
+
+  command_->Run();
+
+  const auto result_code = static_cast<mobile_apis::Result::eType>(
+      (*response_message)[strings::msg_params][strings::result_code].asInt());
+  EXPECT_EQ(result_code, Result::SUCCESS);
+
+  const bool success =
+      (*response_message)[strings::msg_params][strings::success].asBool();
+  EXPECT_TRUE(success);
+}
+
+}  // close_application_response
+}  // mobile_command_test
+}  // command_test
+}  // components
+}  // test

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -2608,6 +2608,7 @@
         <element name="UnsubscribeWayPointsID" value="47" hexvalue="2F" since="4.1" />
         <element name="GetSystemCapabilityID" value="48" hexvalue="30" since="4.5" />
         <element name="SendHapticDataID" value="49" hexvalue="31" since="4.5" />
+        <element name="CloseApplicationID" value="51" hexvalue="33" since="5.0"/>
         
         <!--
          Base Notifications
@@ -6930,6 +6931,27 @@
             <element name="REJECTED"/>
         </param>
         
+        <param name="info" type="String" maxlength="1000" mandatory="false" platform="documentation">
+            <description>Provides additional human readable info regarding the result.</description>
+        </param>
+    </function>
+
+    <function name="CloseApplication" functionID="CloseApplicationID" messagetype="request" since="5.0">
+    </function>
+
+    <function name="CloseApplication" functionID="CloseApplicationID" messagetype="response" since="5.0">
+        <param name="success" type="Boolean" platform="documentation" mandatory="true">
+            <description> true if successful; false, if failed </description>
+        </param>
+
+        <param name="resultCode" type="Result" platform="documentation" mandatory="true" >
+            <element name="SUCCESS"/>
+            <element name="DISALLOWED"/>
+            <element name="APPLICATION_NOT_REGISTERED"/>
+            <element name="GENERIC_ERROR"/>
+            <element name="IGNORED"/>
+        </param>
+
         <param name="info" type="String" maxlength="1000" mandatory="false" platform="documentation">
             <description>Provides additional human readable info regarding the result.</description>
         </param>


### PR DESCRIPTION
Implements #1931

This PR is **ready** for review.

### Risk
This PR makes **major** API changes.

### Testing Plan
Unit tests.

### Summary
This PR provides a new RPC called CloseApplication, which can be used by an app
to send itself into HMI_NONE.

A registered application can send this RPC to transit from any HMI level
to HMI_NONE. The application will receive an OnHMIStatus notification
which then leads to remove the lock screen from the phone app. Different
to unregister or re-register the application stays registered but will

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)