### PR TITLE
Sdl passenger mode unit tests

### DIFF
--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_driver_distraction_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_driver_distraction_notification.cc
@@ -108,14 +108,12 @@ OnDriverDistractionNotification::~OnDriverDistractionNotification() {}
 
 void OnDriverDistractionNotification::Run() {
   LOG4CXX_AUTO_TRACE(logger_);
-  const hmi_apis::Common_DriverDistractionState::eType state =
+  const auto state =
       static_cast<hmi_apis::Common_DriverDistractionState::eType>(
           (*message_)[strings::msg_params][hmi_notification::state].asInt());
   application_manager_.set_driver_distraction_state(state);
 
-  smart_objects::SmartObjectSPtr on_driver_distraction =
-      std::make_shared<smart_objects::SmartObject>();
-
+  auto on_driver_distraction = std::make_shared<smart_objects::SmartObject>();
   if (!on_driver_distraction) {
     LOG4CXX_ERROR(logger_, "NULL pointer");
     return;

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/on_driver_distraction_notification_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/on_driver_distraction_notification_test.cc
@@ -66,8 +66,10 @@ class HMIOnDriverDistractionNotificationTest
     : public CommandsTest<CommandsTestMocks::kIsNice> {
  public:
   HMIOnDriverDistractionNotificationTest()
-      : app_set_lock_(std::make_shared<sync_primitives::Lock>())
+      : mock_app_(CreateMockApp()),
+        app_set_lock_(std::make_shared<sync_primitives::Lock>())
       , accessor(app_set_, app_set_lock_) {
+    app_set_.insert(mock_app_);
     InitMocksRelations();
   }
 
@@ -82,8 +84,6 @@ class HMIOnDriverDistractionNotificationTest
       mock_policy_handler_interface_;
 
   void InitMocksRelations() {
-    mock_app_ = CreateMockApp();
-    app_set_.insert(mock_app_);
     ON_CALL(app_mngr_, applications()).WillByDefault(Return(accessor));
     ON_CALL(app_mngr_, GetPolicyHandler())
         .WillByDefault(ReturnRef(mock_policy_handler_interface_));

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/on_driver_distraction_notification_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/on_driver_distraction_notification_test.cc
@@ -54,10 +54,13 @@ namespace on_driver_distraction_notification {
 using ::testing::_;
 using ::testing::Return;
 using ::testing::Eq;
+using ::testing::NiceMock;
+using ::testing::SaveArg;
 namespace am = ::application_manager;
 using am::commands::MessageSharedPtr;
 using sdl_rpc_plugin::commands::hmi::OnDriverDistractionNotification;
 using namespace am::commands;
+using test::components::commands_test::MobileResultCodeIs;
 
 typedef std::shared_ptr<OnDriverDistractionNotification> NotificationPtr;
 
@@ -67,7 +70,8 @@ class HMIOnDriverDistractionNotificationTest
   HMIOnDriverDistractionNotificationTest()
       : app_set_lock_(std::make_shared<sync_primitives::Lock>()) {}
   std::shared_ptr<sync_primitives::Lock> app_set_lock_;
-  policy_test::MockPolicyHandlerInterface mock_policy_handler_interface_;
+  NiceMock<policy_test::MockPolicyHandlerInterface>
+      mock_policy_handler_interface_;
 };
 
 MATCHER_P2(CheckNotificationParams, function_id, state, "") {
@@ -88,68 +92,111 @@ ACTION_P(GetArg3, result) {
 }
 
 TEST_F(HMIOnDriverDistractionNotificationTest, Run_PushMobileMessage_SUCCESS) {
-  const hmi_apis::Common_DriverDistractionState::eType state =
-      hmi_apis::Common_DriverDistractionState::DD_ON;
+  const auto state = hmi_apis::Common_DriverDistractionState::DD_ON;
   MessageSharedPtr commands_msg(CreateMessage(smart_objects::SmartType_Map));
   (*commands_msg)[am::strings::msg_params][am::hmi_notification::state] = state;
 
   NotificationPtr command(
       CreateCommand<OnDriverDistractionNotification>(commands_msg));
 
-  EXPECT_CALL(app_mngr_, set_driver_distraction_state(Eq(state)));
-
   MockAppPtr mock_app = CreateMockApp();
   am::ApplicationSet app_set;
   app_set.insert(mock_app);
 
   DataAccessor<am::ApplicationSet> accessor(app_set, app_set_lock_);
-  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(accessor));
+  ON_CALL(app_mngr_, applications()).WillByDefault(Return(accessor));
+  ON_CALL(app_mngr_, GetPolicyHandler())
+      .WillByDefault(ReturnRef(mock_policy_handler_interface_));
+  ON_CALL(mock_policy_handler_interface_, LockScreenDismissalEnabledState())
+      .WillByDefault(Return(utils::OptionalVal<bool>(true)));
+
   policy::CheckPermissionResult result;
   result.hmi_level_permitted = policy::kRpcDisallowed;
-  EXPECT_CALL(app_mngr_, GetPolicyHandler())
-      .WillOnce(ReturnRef(mock_policy_handler_interface_));
   EXPECT_CALL(mock_policy_handler_interface_, CheckPermissions(_, _, _, _))
       .WillOnce(GetArg3(&result));
-
   EXPECT_CALL(*mock_app,
               PushMobileMessage(CheckNotificationParams(
                   am::mobile_api::FunctionID::OnDriverDistractionID, state)));
 
+  EXPECT_CALL(app_mngr_, set_driver_distraction_state(Eq(state)));
   command->Run();
 }
 
 TEST_F(HMIOnDriverDistractionNotificationTest,
        Run_SendNotificationToMobile_SUCCESS) {
-  const hmi_apis::Common_DriverDistractionState::eType state =
-      hmi_apis::Common_DriverDistractionState::DD_ON;
+  const auto state = hmi_apis::Common_DriverDistractionState::DD_ON;
   MessageSharedPtr commands_msg(CreateMessage(smart_objects::SmartType_Map));
   (*commands_msg)[am::strings::msg_params][am::hmi_notification::state] = state;
 
   NotificationPtr command(
       CreateCommand<OnDriverDistractionNotification>(commands_msg));
 
+  MockAppPtr mock_app = CreateMockApp();
+  am::ApplicationSet app_set;
+  app_set.insert(mock_app);
+
+  DataAccessor<am::ApplicationSet> accessor(app_set, app_set_lock_);
+  ON_CALL(app_mngr_, applications()).WillByDefault(Return(accessor));
+  ON_CALL(app_mngr_, GetPolicyHandler())
+      .WillByDefault(ReturnRef(mock_policy_handler_interface_));
+  ON_CALL(mock_policy_handler_interface_, LockScreenDismissalEnabledState())
+      .WillByDefault(Return(utils::OptionalVal<bool>(true)));
+
   EXPECT_CALL(app_mngr_, set_driver_distraction_state(Eq(state)));
+
+  policy::CheckPermissionResult result;
+  result.hmi_level_permitted = policy::kRpcAllowed;
+  EXPECT_CALL(mock_policy_handler_interface_, CheckPermissions(_, _, _, _))
+      .WillOnce(GetArg3(&result));
+
+  EXPECT_CALL(mock_rpc_service_,
+              ManageMobileCommand(
+                  CheckNotificationParams(
+                      am::mobile_api::FunctionID::OnDriverDistractionID, state),
+                  Command::CommandSource::SOURCE_SDL));
+  command->Run();
+}
+
+TEST_F(HMIOnDriverDistractionNotificationTest,
+       Run_SendNotificationIfLockScreenDismissalMissed) {
+  typedef utils::OptionalVal<bool> OptionalBool;
+  const auto state = hmi_apis::Common_DriverDistractionState::DD_ON;
+  MessageSharedPtr commands_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*commands_msg)[am::strings::msg_params][am::hmi_notification::state] = state;
+
+  NotificationPtr command(
+      CreateCommand<OnDriverDistractionNotification>(commands_msg));
 
   MockAppPtr mock_app = CreateMockApp();
   am::ApplicationSet app_set;
   app_set.insert(mock_app);
 
   DataAccessor<am::ApplicationSet> accessor(app_set, app_set_lock_);
-  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(accessor));
+  ON_CALL(app_mngr_, applications()).WillByDefault(Return(accessor));
+  ON_CALL(app_mngr_, GetPolicyHandler())
+      .WillByDefault(ReturnRef(mock_policy_handler_interface_));
+
+  OptionalBool empty(OptionalBool::EMPTY);
+
+  ON_CALL(mock_policy_handler_interface_, LockScreenDismissalEnabledState())
+      .WillByDefault(Return(empty));
 
   policy::CheckPermissionResult result;
   result.hmi_level_permitted = policy::kRpcAllowed;
-  EXPECT_CALL(app_mngr_, GetPolicyHandler())
-      .WillOnce(ReturnRef(mock_policy_handler_interface_));
-  EXPECT_CALL(mock_policy_handler_interface_, CheckPermissions(_, _, _, _))
-      .WillOnce(GetArg3(&result));
+  ON_CALL(mock_policy_handler_interface_, CheckPermissions(_, _, _, _))
+      .WillByDefault(GetArg3(&result));
+
+  MessageSharedPtr command_result;
   EXPECT_CALL(mock_rpc_service_,
-              ManageMobileCommand(
-                  CheckNotificationParams(
-                      am::mobile_api::FunctionID::OnDriverDistractionID, state),
-                  Command::CommandSource::SOURCE_SDL));
+              ManageMobileCommand(_, Command::CommandSource::SOURCE_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&command_result), Return(true)));
 
   command->Run();
+
+  auto& msg_params =
+      (*command_result)[application_manager::strings::msg_params];
+  EXPECT_FALSE(msg_params.keyExists(
+      application_manager::mobile_notification::lock_screen_dismissal_enabled));
 }
 
 }  // on_driver_distraction_notification

--- a/src/components/utils/include/utils/optional.h
+++ b/src/components/utils/include/utils/optional.h
@@ -103,7 +103,7 @@ class Optional<ObjectType, ErrorType, StoragePolicy_CopyValue> {
    * @brief Copy constructor of Optional
    */
   Optional(const ClassName& copy)
-      : object_(new ObjectType(*copy))
+      : object_(copy.is_initialized_ ? new ObjectType(*copy) : nullptr)
       , error_(copy.error())
       , is_initialized_(copy) {}
 


### PR DESCRIPTION
Unit tests fix after implementation https://github.com/smartdevicelink/sdl_core/issues/2134 

Additional unit test for SDL passenger mode `lockScreenDismissalEnabled` added

Fixed bug : crash on empty optional copy

This PR is **ready** for review.
