### PR TITLE
Feature/sdl passenger mode

### DIFF
--- a/src/appMain/sdl_preloaded_pt.json
+++ b/src/appMain/sdl_preloaded_pt.json
@@ -33,7 +33,8 @@
                 "COMMUNICATION": 6,
                 "NORMAL": 4,
                 "NONE": 0
-            }
+            },
+            "lock_screen_dismissal_enabled": true
         },
         "functional_groupings": {
             "Base-4": {

--- a/src/components/application_manager/include/application_manager/policies/policy_handler.h
+++ b/src/components/application_manager/include/application_manager/policies/policy_handler.h
@@ -202,6 +202,8 @@ class PolicyHandler : public PolicyHandlerInterface,
   uint32_t TimeoutExchangeMSec() const OVERRIDE;
   void OnExceededTimeout() OVERRIDE;
   void OnSystemReady() OVERRIDE;
+  const utils::OptionalVal<bool> LockScreenDismissalEnabledState()
+      const OVERRIDE;
   void PTUpdatedAt(Counters counter, int value) OVERRIDE;
   void add_listener(PolicyHandlerObserver* listener) OVERRIDE;
   void remove_listener(PolicyHandlerObserver* listener) OVERRIDE;

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -419,6 +419,7 @@ namespace mobile_notification {
 extern const char* state;
 extern const char* syncp_timeout;
 extern const char* syncp_url;
+extern const char* lock_screen_dismissal_enabled;
 }  // namespace mobile_notification
 
 namespace hmi_levels {

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/on_driver_distraction_notification_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/on_driver_distraction_notification_test.cc
@@ -54,20 +54,40 @@ namespace on_driver_distraction_notification {
 using ::testing::_;
 using ::testing::Return;
 using ::testing::Eq;
+using ::testing::NiceMock;
+using ::testing::SaveArg;
 namespace am = ::application_manager;
 using am::commands::MessageSharedPtr;
 using sdl_rpc_plugin::commands::hmi::OnDriverDistractionNotification;
 using namespace am::commands;
-
-typedef std::shared_ptr<OnDriverDistractionNotification> NotificationPtr;
+using test::components::commands_test::MobileResultCodeIs;
 
 class HMIOnDriverDistractionNotificationTest
     : public CommandsTest<CommandsTestMocks::kIsNice> {
  public:
   HMIOnDriverDistractionNotificationTest()
-      : app_set_lock_(std::make_shared<sync_primitives::Lock>()) {}
+      : mock_app_(CreateMockApp())
+      , app_set_lock_(std::make_shared<sync_primitives::Lock>())
+      , accessor(app_set_, app_set_lock_) {
+    app_set_.insert(mock_app_);
+    InitMocksRelations();
+  }
+
+  typedef std::shared_ptr<OnDriverDistractionNotification> NotificationPtr;
+  typedef utils::OptionalVal<bool> OptionalBool;
+
+  MockAppPtr mock_app_;
   std::shared_ptr<sync_primitives::Lock> app_set_lock_;
-  policy_test::MockPolicyHandlerInterface mock_policy_handler_interface_;
+  am::ApplicationSet app_set_;
+  DataAccessor<am::ApplicationSet> accessor;
+  NiceMock<policy_test::MockPolicyHandlerInterface>
+      mock_policy_handler_interface_;
+
+  void InitMocksRelations() {
+    ON_CALL(app_mngr_, applications()).WillByDefault(Return(accessor));
+    ON_CALL(app_mngr_, GetPolicyHandler())
+        .WillByDefault(ReturnRef(mock_policy_handler_interface_));
+  }
 };
 
 MATCHER_P2(CheckNotificationParams, function_id, state, "") {
@@ -87,41 +107,9 @@ ACTION_P(GetArg3, result) {
   arg3 = *result;
 }
 
-TEST_F(HMIOnDriverDistractionNotificationTest, Run_PushMobileMessage_SUCCESS) {
-  const hmi_apis::Common_DriverDistractionState::eType state =
-      hmi_apis::Common_DriverDistractionState::DD_ON;
-  MessageSharedPtr commands_msg(CreateMessage(smart_objects::SmartType_Map));
-  (*commands_msg)[am::strings::msg_params][am::hmi_notification::state] = state;
-
-  NotificationPtr command(
-      CreateCommand<OnDriverDistractionNotification>(commands_msg));
-
-  EXPECT_CALL(app_mngr_, set_driver_distraction_state(Eq(state)));
-
-  MockAppPtr mock_app = CreateMockApp();
-  am::ApplicationSet app_set;
-  app_set.insert(mock_app);
-
-  DataAccessor<am::ApplicationSet> accessor(app_set, app_set_lock_);
-  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(accessor));
-  policy::CheckPermissionResult result;
-  result.hmi_level_permitted = policy::kRpcDisallowed;
-  EXPECT_CALL(app_mngr_, GetPolicyHandler())
-      .WillOnce(ReturnRef(mock_policy_handler_interface_));
-  EXPECT_CALL(mock_policy_handler_interface_, CheckPermissions(_, _, _, _))
-      .WillOnce(GetArg3(&result));
-
-  EXPECT_CALL(*mock_app,
-              PushMobileMessage(CheckNotificationParams(
-                  am::mobile_api::FunctionID::OnDriverDistractionID, state)));
-
-  command->Run();
-}
-
 TEST_F(HMIOnDriverDistractionNotificationTest,
        Run_SendNotificationToMobile_SUCCESS) {
-  const hmi_apis::Common_DriverDistractionState::eType state =
-      hmi_apis::Common_DriverDistractionState::DD_ON;
+  const auto state = hmi_apis::Common_DriverDistractionState::DD_ON;
   MessageSharedPtr commands_msg(CreateMessage(smart_objects::SmartType_Map));
   (*commands_msg)[am::strings::msg_params][am::hmi_notification::state] = state;
 
@@ -130,26 +118,73 @@ TEST_F(HMIOnDriverDistractionNotificationTest,
 
   EXPECT_CALL(app_mngr_, set_driver_distraction_state(Eq(state)));
 
-  MockAppPtr mock_app = CreateMockApp();
-  am::ApplicationSet app_set;
-  app_set.insert(mock_app);
-
-  DataAccessor<am::ApplicationSet> accessor(app_set, app_set_lock_);
-  EXPECT_CALL(app_mngr_, applications()).WillOnce(Return(accessor));
+  ON_CALL(mock_policy_handler_interface_, LockScreenDismissalEnabledState())
+      .WillByDefault(Return(OptionalBool(true)));
 
   policy::CheckPermissionResult result;
   result.hmi_level_permitted = policy::kRpcAllowed;
-  EXPECT_CALL(app_mngr_, GetPolicyHandler())
-      .WillOnce(ReturnRef(mock_policy_handler_interface_));
   EXPECT_CALL(mock_policy_handler_interface_, CheckPermissions(_, _, _, _))
       .WillOnce(GetArg3(&result));
+
   EXPECT_CALL(mock_rpc_service_,
               ManageMobileCommand(
                   CheckNotificationParams(
                       am::mobile_api::FunctionID::OnDriverDistractionID, state),
                   Command::CommandSource::SOURCE_SDL));
+  command->Run();
+}
+
+TEST_F(HMIOnDriverDistractionNotificationTest,
+       Run_PushMobileMessage_If_DisallowedByPolicy) {
+  const auto state = hmi_apis::Common_DriverDistractionState::DD_ON;
+  MessageSharedPtr commands_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*commands_msg)[am::strings::msg_params][am::hmi_notification::state] = state;
+  NotificationPtr command(
+      CreateCommand<OnDriverDistractionNotification>(commands_msg));
+
+  ON_CALL(mock_policy_handler_interface_, LockScreenDismissalEnabledState())
+      .WillByDefault(Return(OptionalBool(true)));
+
+  policy::CheckPermissionResult result;
+  result.hmi_level_permitted = policy::kRpcDisallowed;
+  EXPECT_CALL(mock_policy_handler_interface_, CheckPermissions(_, _, _, _))
+      .WillOnce(GetArg3(&result));
+  EXPECT_CALL(*mock_app_,
+              PushMobileMessage(CheckNotificationParams(
+                  am::mobile_api::FunctionID::OnDriverDistractionID, state)));
+
+  EXPECT_CALL(app_mngr_, set_driver_distraction_state(Eq(state)));
+  command->Run();
+}
+
+TEST_F(HMIOnDriverDistractionNotificationTest,
+       Run_SendNotificationIfLockScreenDismissalMissed) {
+  const auto state = hmi_apis::Common_DriverDistractionState::DD_ON;
+  MessageSharedPtr commands_msg(CreateMessage(smart_objects::SmartType_Map));
+  (*commands_msg)[am::strings::msg_params][am::hmi_notification::state] = state;
+
+  NotificationPtr command(
+      CreateCommand<OnDriverDistractionNotification>(commands_msg));
+
+  ON_CALL(mock_policy_handler_interface_, LockScreenDismissalEnabledState())
+      .WillByDefault(Return(OptionalBool(OptionalBool::EMPTY)));
+
+  policy::CheckPermissionResult result;
+  result.hmi_level_permitted = policy::kRpcAllowed;
+  ON_CALL(mock_policy_handler_interface_, CheckPermissions(_, _, _, _))
+      .WillByDefault(GetArg3(&result));
+
+  MessageSharedPtr command_result;
+  EXPECT_CALL(mock_rpc_service_,
+              ManageMobileCommand(_, Command::CommandSource::SOURCE_SDL))
+      .WillOnce(DoAll(SaveArg<0>(&command_result), Return(true)));
 
   command->Run();
+
+  auto& msg_params =
+      (*command_result)[application_manager::strings::msg_params];
+  EXPECT_FALSE(msg_params.keyExists(
+      application_manager::mobile_notification::lock_screen_dismissal_enabled));
 }
 
 }  // on_driver_distraction_notification

--- a/src/components/application_manager/src/application_manager_impl.cc
+++ b/src/components/application_manager/src/application_manager_impl.cc
@@ -3387,6 +3387,18 @@ void ApplicationManagerImpl::SendDriverDistractionState(
       mobile_api::FunctionID::OnDriverDistractionID;
   (*on_driver_distraction)[strings::msg_params][mobile_notification::state] =
       driver_distraction_state();
+  const auto lock_screen_dismissal =
+      policy_handler_->LockScreenDismissalEnabledState();
+
+  if (lock_screen_dismissal &&
+      hmi_apis::Common_DriverDistractionState::DD_ON ==
+          driver_distraction_state()) {
+    (*on_driver_distraction)
+        [strings::msg_params]
+        [mobile_notification::lock_screen_dismissal_enabled] =
+            *lock_screen_dismissal;
+  }
+
   (*on_driver_distraction)[strings::params][strings::connection_key] =
       application->app_id();
 

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1600,6 +1600,12 @@ void PolicyHandler::OnSystemReady() {
   policy_manager_->OnSystemReady();
 }
 
+const utils::OptionalVal<bool> PolicyHandler::LockScreenDismissalEnabledState()
+    const {
+  POLICY_LIB_CHECK(utils::OptionalVal<bool>(utils::OptionalVal<bool>::EMPTY));
+  return policy_manager_->LockScreenDismissalEnabledState();
+}
+
 void PolicyHandler::PTUpdatedAt(Counters counter, int value) {
   POLICY_LIB_CHECK_VOID();
   policy_manager_->PTUpdatedAt(counter, value);

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -379,6 +379,7 @@ namespace mobile_notification {
 const char* state = "state";
 const char* syncp_timeout = "Timeout";
 const char* syncp_url = "URL";
+const char* lock_screen_dismissal_enabled = "lockScreenDismissalEnabled";
 }  // namespace mobile_notification
 
 namespace hmi_levels {

--- a/src/components/include/application_manager/policies/policy_handler_interface.h
+++ b/src/components/include/application_manager/policies/policy_handler_interface.h
@@ -44,6 +44,7 @@
 #include "policy/usage_statistics/statistics_manager.h"
 #include "utils/custom_string.h"
 #include "utils/callable.h"
+#include "utils/optional.h"
 #include "policy/policy_settings.h"
 #include "smart_objects/smart_object.h"
 #include "policy/policy_types.h"
@@ -120,6 +121,8 @@ class PolicyHandlerInterface {
   virtual uint32_t TimeoutExchangeMSec() const = 0;
   virtual void OnExceededTimeout() = 0;
   virtual void OnSystemReady() = 0;
+  virtual const utils::OptionalVal<bool> LockScreenDismissalEnabledState()
+      const = 0;
   virtual void PTUpdatedAt(Counters counter, int value) = 0;
   virtual void add_listener(PolicyHandlerObserver* listener) = 0;
   virtual void remove_listener(PolicyHandlerObserver* listener) = 0;

--- a/src/components/include/policy/policy_external/policy/policy_manager.h
+++ b/src/components/include/policy/policy_external/policy/policy_manager.h
@@ -36,6 +36,7 @@
 #include <vector>
 
 #include "utils/callable.h"
+#include "utils/optional.h"
 
 #include "policy/policy_types.h"
 #include "policy/policy_table/types.h"
@@ -154,6 +155,15 @@ class PolicyManager : public usage_statistics::StatisticsManager {
    * @return true if exceeded
    */
   virtual void KmsChanged(int kilometers) = 0;
+
+  /**
+   * @brief Returns state of the lock screen that could be able to be dismissed
+   * while connected to SDL, allowing users the ability to interact with the
+   * app.
+   * @return bool True if lock screen can be dismissed.
+   */
+  virtual const utils::OptionalVal<bool> LockScreenDismissalEnabledState()
+      const = 0;
 
   /**
    * @brief Increments counter of ignition cycles

--- a/src/components/include/policy/policy_regular/policy/policy_manager.h
+++ b/src/components/include/policy/policy_regular/policy/policy_manager.h
@@ -37,6 +37,8 @@
 #include <cstdint>
 
 #include "utils/callable.h"
+#include "utils/optional.h"
+
 #include "policy/policy_types.h"
 #include "policy/policy_table/types.h"
 #include "policy/policy_listener.h"
@@ -154,6 +156,15 @@ class PolicyManager : public usage_statistics::StatisticsManager {
    * @return true if exceeded
    */
   virtual void KmsChanged(int kilometers) = 0;
+
+  /**
+   * @brief Returns state of the lock screen that could be able to be dismissed
+   * while connected to SDL, allowing users the ability to interact with the
+   * app.
+   * @return bool True if lock screen can be dismissed.
+   */
+  virtual const utils::OptionalVal<bool> LockScreenDismissalEnabledState()
+      const = 0;
 
   /**
    * @brief Increments counter of ignition cycles

--- a/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
+++ b/src/components/include/test/application_manager/policies/mock_policy_handler_interface.h
@@ -108,6 +108,8 @@ class MockPolicyHandlerInterface : public policy::PolicyHandlerInterface {
   MOCK_CONST_METHOD0(TimeoutExchangeMSec, uint32_t());
   MOCK_METHOD0(OnExceededTimeout, void());
   MOCK_METHOD0(OnSystemReady, void());
+  MOCK_CONST_METHOD0(LockScreenDismissalEnabledState,
+                     const utils::OptionalVal<bool>());
   MOCK_METHOD2(PTUpdatedAt, void(policy::Counters counter, int value));
   MOCK_METHOD1(add_listener, void(policy::PolicyHandlerObserver* listener));
   MOCK_METHOD1(remove_listener, void(policy::PolicyHandlerObserver* listener));

--- a/src/components/include/test/policy/policy_external/policy/mock_cache_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_cache_manager.h
@@ -76,6 +76,8 @@ class MockCacheManagerInterface : public ::policy::CacheManagerInterface {
   MOCK_METHOD1(SecondsBetweenRetries, bool(std::vector<int>& seconds));
   MOCK_CONST_METHOD1(IsDeviceConsentCached, bool(const std::string& device_id));
   MOCK_CONST_METHOD0(GetVehicleInfo, const VehicleInfo());
+  MOCK_CONST_METHOD0(LockScreenDismissalEnabledState,
+                     const utils::OptionalVal<bool>());
   MOCK_CONST_METHOD1(GetDeviceConsent,
                      DeviceConsent(const std::string& device_id));
   MOCK_METHOD2(SetDeviceConsent,

--- a/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_external/policy/mock_policy_manager.h
@@ -77,6 +77,8 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD0(ResetUserConsent, bool());
   MOCK_CONST_METHOD0(GetPolicyTableStatus, std::string());
   MOCK_METHOD1(KmsChanged, void(int kilometers));
+  MOCK_CONST_METHOD0(LockScreenDismissalEnabledState,
+                     const utils::OptionalVal<bool>());
   MOCK_METHOD0(IncrementIgnitionCycles, void());
   MOCK_METHOD0(ForcePTExchange, std::string());
   MOCK_METHOD0(ForcePTExchangeAtUserRequest, std::string());

--- a/src/components/include/test/policy/policy_regular/policy/mock_cache_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_cache_manager.h
@@ -63,6 +63,8 @@ class MockCacheManagerInterface : public CacheManagerInterface {
   MOCK_METHOD0(TimeoutResponse, int());
   MOCK_METHOD1(SecondsBetweenRetries, bool(std::vector<int>& seconds));
   MOCK_CONST_METHOD0(GetVehicleInfo, const VehicleInfo());
+  MOCK_CONST_METHOD0(LockScreenDismissalEnabledState,
+                     const utils::OptionalVal<bool>());
   MOCK_METHOD1(SetVINValue, bool(const std::string& value));
   MOCK_METHOD2(GetUserFriendlyMsg,
                std::vector<UserFriendlyMessage>(

--- a/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
+++ b/src/components/include/test/policy/policy_regular/policy/mock_policy_manager.h
@@ -78,6 +78,8 @@ class MockPolicyManager : public PolicyManager {
   MOCK_METHOD0(ResetUserConsent, bool());
   MOCK_CONST_METHOD0(GetPolicyTableStatus, std::string());
   MOCK_METHOD1(KmsChanged, void(int kilometers));
+  MOCK_CONST_METHOD0(LockScreenDismissalEnabledState,
+                     const utils::OptionalVal<bool>());
   MOCK_METHOD0(IncrementIgnitionCycles, void());
   MOCK_METHOD0(ForcePTExchange, std::string());
   MOCK_METHOD0(ForcePTExchangeAtUserRequest, std::string());

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -6775,6 +6775,13 @@
         <param name="state" type="DriverDistractionState" mandatory="true">
             <description>Current State of Driver Distraction</description>
         </param>
+        <param name="lockScreenDismissalEnabled" type="Boolean" mandatory="false">
+            <description>
+                If enabled, the lock screen will be able to be dismissed while connected to SDL, allowing users 
+                the ability to interact with the app. Dismissals should include a warning to the user and ensure 
+                that they are not the driver.
+            </description>
+        </param>
     </function>
     
     <function name="OnPermissionsChange" functionID="OnPermissionsChangeID" messagetype="notification" since="2.0">

--- a/src/components/policy/policy_external/include/policy/cache_manager.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager.h
@@ -158,6 +158,9 @@ class CacheManager : public CacheManagerInterface {
    */
   virtual const VehicleInfo GetVehicleInfo() const;
 
+  const utils::OptionalVal<bool> LockScreenDismissalEnabledState()
+      const OVERRIDE;
+
   /**
    * @brief Allows to update 'vin' field in module_meta table.
    *

--- a/src/components/policy/policy_external/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_external/include/policy/cache_manager_interface.h
@@ -35,6 +35,7 @@
 
 #include <string>
 #include <vector>
+#include "utils/optional.h"
 
 #include "policy/policy_table/types.h"
 #include "policy/pt_representation.h"
@@ -164,6 +165,15 @@ class CacheManagerInterface {
    * @brief Get information about vehicle
    */
   virtual const VehicleInfo GetVehicleInfo() const = 0;
+
+  /**
+   * @brief Returns state of the lock screen that could be able to be dismissed
+   * while connected to SDL, allowing users the ability to interact with the
+   * app.
+   * @return bool True if lock screen can be dismissed.
+   */
+  virtual const utils::OptionalVal<bool> LockScreenDismissalEnabledState()
+      const = 0;
 
   /**
    * @brief Allows to update 'vin' field in module_meta table.

--- a/src/components/policy/policy_external/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_external/include/policy/policy_manager_impl.h
@@ -148,6 +148,9 @@ class PolicyManagerImpl : public PolicyManager {
    */
   void KmsChanged(int kilometers) OVERRIDE;
 
+  const utils::OptionalVal<bool> LockScreenDismissalEnabledState()
+      const OVERRIDE;
+
   /**
    * @brief Increments counter of ignition cycles
    */

--- a/src/components/policy/policy_external/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_external/include/policy/policy_table/types.h
@@ -304,6 +304,7 @@ struct ModuleConfig : CompositeType {
   Optional<String<0, 65535> > certificate;
   Optional<Boolean> preloaded_pt;
   Optional<Boolean> full_app_id_supported;
+  Optional<Boolean> lock_screen_dismissal_enabled;
 
  public:
   ModuleConfig();

--- a/src/components/policy/policy_external/src/cache_manager.cc
+++ b/src/components/policy/policy_external/src/cache_manager.cc
@@ -42,6 +42,7 @@
 
 #include "utils/file_system.h"
 #include "utils/helpers.h"
+
 #include "json/reader.h"
 #include "json/features.h"
 #include "json/writer.h"
@@ -1387,6 +1388,19 @@ const policy::VehicleInfo CacheManager::GetVehicleInfo() const {
                                           << vehicle_info.vehicle_model << ","
                                           << vehicle_info.vehicle_year);
   return vehicle_info;
+}
+
+const utils::OptionalVal<bool> CacheManager::LockScreenDismissalEnabledState()
+    const {
+  utils::OptionalVal<bool> empty(utils::OptionalVal<bool>::EMPTY);
+  CACHE_MANAGER_CHECK(empty);
+  sync_primitives::AutoLock auto_lock(cache_lock_);
+  policy_table::ModuleConfig& module_config = pt_->policy_table.module_config;
+  if (module_config.lock_screen_dismissal_enabled.is_initialized()) {
+    return utils::OptionalVal<bool>(
+        *module_config.lock_screen_dismissal_enabled);
+  }
+  return empty;
 }
 
 std::vector<UserFriendlyMessage> CacheManager::GetUserFriendlyMsg(

--- a/src/components/policy/policy_external/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_external/src/policy_manager_impl.cc
@@ -1656,6 +1656,12 @@ void PolicyManagerImpl::KmsChanged(int kilometers) {
   }
 }
 
+const utils::OptionalVal<bool>
+PolicyManagerImpl::LockScreenDismissalEnabledState() const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  return cache_->LockScreenDismissalEnabledState();
+}
+
 void PolicyManagerImpl::IncrementIgnitionCycles() {
   cache_->IncrementIgnitionCycles();
 }

--- a/src/components/policy/policy_external/src/policy_table/types.cc
+++ b/src/components/policy/policy_external/src/policy_table/types.cc
@@ -570,8 +570,9 @@ ModuleConfig::ModuleConfig(const Json::Value* value__)
     , preloaded_date(impl::ValueMember(value__, "preloaded_date"))
     , certificate(impl::ValueMember(value__, "certificate"))
     , preloaded_pt(impl::ValueMember(value__, "preloaded_pt"))
-    , full_app_id_supported(
-          impl::ValueMember(value__, "full_app_id_supported")) {}
+    , full_app_id_supported(impl::ValueMember(value__, "full_app_id_supported"))
+    , lock_screen_dismissal_enabled(
+          impl::ValueMember(value__, "lock_screen_dismissal_enabled")) {}
 
 void ModuleConfig::SafeCopyFrom(const ModuleConfig& from) {
   exchange_after_x_days = from.exchange_after_x_days;
@@ -583,6 +584,7 @@ void ModuleConfig::SafeCopyFrom(const ModuleConfig& from) {
   endpoints = from.endpoints;
   notifications_per_minute_by_priority =
       from.notifications_per_minute_by_priority;
+  lock_screen_dismissal_enabled = from.lock_screen_dismissal_enabled;
 
   certificate.assign_if_valid(from.certificate);
   vehicle_make.assign_if_valid(from.vehicle_make);
@@ -663,6 +665,9 @@ bool ModuleConfig::is_valid() const {
     return false;
   }
   if (!preloaded_date.is_valid()) {
+    return false;
+  }
+  if (!lock_screen_dismissal_enabled.is_valid()) {
     return false;
   }
   return Validate();

--- a/src/components/policy/policy_external/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_external/src/sql_pt_queries.cc
@@ -76,7 +76,8 @@ const std::string kCreateSchema =
     "  `vehicle_model` VARCHAR(45), "
     "  `vehicle_year` VARCHAR(4), "
     "  `preloaded_date` VARCHAR (10), "
-    "  `certificate` VARCHAR (45) "
+    "  `certificate` VARCHAR (45), "
+    "  `lock_screen_dismissal_enabled` BOOL"
     "); "
     "CREATE TABLE IF NOT EXISTS `functional_group`( "
     "  `id` INTEGER PRIMARY KEY NOT NULL, "
@@ -418,7 +419,7 @@ const std::string kInsertInitData =
     "  VALUES (0, 0, 0, 0); "
     "INSERT OR IGNORE INTO `module_config` (`preloaded_pt`, `is_first_run`,"
     "  `exchange_after_x_ignition_cycles`, `exchange_after_x_kilometers`, "
-    "  `exchange_after_x_days`, `timeout_after_x_seconds`) "
+    "  `exchange_after_x_days`, `timeout_after_x_seconds`)"
     "  VALUES(1, 0, 0, 0, 0, 0); "
     "INSERT OR IGNORE INTO `priority`(`value`) VALUES ('EMERGENCY'); "
     "INSERT OR IGNORE INTO `priority`(`value`) VALUES ('NAVIGATION'); "
@@ -668,7 +669,7 @@ const std::string kUpdateModuleConfig =
     "  `exchange_after_x_kilometers` = ?, `exchange_after_x_days` = ?, "
     "  `timeout_after_x_seconds` = ?, `vehicle_make` = ?, "
     "  `vehicle_model` = ?, `vehicle_year` = ?, `preloaded_date` = ?, "
-    "  `certificate` = ? ";
+    "  `certificate` = ?, lock_screen_dismissal_enabled = ?";
 
 const std::string kInsertEndpoint =
     "INSERT INTO `endpoint` (`service`, `url`, `application_id`) "
@@ -719,7 +720,8 @@ const std::string kSelectModuleConfig =
     "SELECT `preloaded_pt`, `exchange_after_x_ignition_cycles`, "
     " `exchange_after_x_kilometers`, `exchange_after_x_days`, "
     " `timeout_after_x_seconds`, `vehicle_make`,"
-    " `vehicle_model`, `vehicle_year`, `preloaded_date`, `certificate` "
+    " `vehicle_model`, `vehicle_year`, `preloaded_date`, `certificate`, "
+    " `lock_screen_dismissal_enabled` "
     " FROM `module_config`";
 
 const std::string kSelectEndpoints =

--- a/src/components/policy/policy_external/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_external/src/sql_pt_representation.cc
@@ -552,6 +552,9 @@ void SQLPTRepresentation::GatherModuleConfig(
     *config->vehicle_year = query.GetString(7);
     *config->preloaded_date = query.GetString(8);
     *config->certificate = query.GetString(9);
+    if (!query.IsNull(10)) {
+      *config->lock_screen_dismissal_enabled = query.GetBoolean(10);
+    }
   }
 
   utils::dbms::SQLQuery endpoints(db());
@@ -1267,6 +1270,12 @@ bool SQLPTRepresentation::SaveModuleConfig(
       : query.Bind(8);
   config.certificate.is_initialized() ? query.Bind(9, *(config.certificate))
                                       : query.Bind(9);
+
+  if (config.lock_screen_dismissal_enabled.is_initialized()) {
+    query.Bind(10, *(config.lock_screen_dismissal_enabled));
+  } else {
+    query.Bind(10);
+  }
 
   if (!query.Exec()) {
     LOG4CXX_WARN(logger_, "Incorrect update module config");

--- a/src/components/policy/policy_regular/include/policy/cache_manager.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager.h
@@ -146,6 +146,9 @@ class CacheManager : public CacheManagerInterface {
    */
   virtual const VehicleInfo GetVehicleInfo() const;
 
+  const utils::OptionalVal<bool> LockScreenDismissalEnabledState()
+      const OVERRIDE;
+
   /**
    * @brief Allows to update 'vin' field in module_meta table.
    *

--- a/src/components/policy/policy_regular/include/policy/cache_manager_interface.h
+++ b/src/components/policy/policy_regular/include/policy/cache_manager_interface.h
@@ -36,6 +36,7 @@
 #include <string>
 #include <vector>
 
+#include "utils/optional.h"
 #include "policy/usage_statistics/counter.h"
 #include "policy/policy_types.h"
 #include "policy/policy_settings.h"
@@ -150,6 +151,15 @@ class CacheManagerInterface {
    * @brief Get information about vehicle
    */
   virtual const VehicleInfo GetVehicleInfo() const = 0;
+
+  /**
+   * @brief Returns state of the lock screen that could be able to be dismissed
+   * while connected to SDL, allowing users the ability to interact with the
+   * app.
+   * @return bool True if lock screen can be dismissed.
+   */
+  virtual const utils::OptionalVal<bool> LockScreenDismissalEnabledState()
+      const = 0;
 
   /**
    * @brief Allows to update 'vin' field in module_meta table.

--- a/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
+++ b/src/components/policy/policy_regular/include/policy/policy_manager_impl.h
@@ -153,6 +153,9 @@ class PolicyManagerImpl : public PolicyManager {
    */
   void KmsChanged(int kilometers) OVERRIDE;
 
+  const utils::OptionalVal<bool> LockScreenDismissalEnabledState()
+      const OVERRIDE;
+
   /**
    * @brief Increments counter of ignition cycles
    */

--- a/src/components/policy/policy_regular/include/policy/policy_table/types.h
+++ b/src/components/policy/policy_regular/include/policy/policy_table/types.h
@@ -243,6 +243,7 @@ struct ModuleConfig : CompositeType {
   Optional<String<4, 4> > vehicle_year;
   Optional<String<0, 10> > preloaded_date;
   Optional<String<0, 65535> > certificate;
+  Optional<Boolean> lock_screen_dismissal_enabled;
 
  public:
   ModuleConfig();

--- a/src/components/policy/policy_regular/src/cache_manager.cc
+++ b/src/components/policy/policy_regular/src/cache_manager.cc
@@ -682,6 +682,19 @@ const policy::VehicleInfo CacheManager::GetVehicleInfo() const {
   return vehicle_info;
 }
 
+const utils::OptionalVal<bool> CacheManager::LockScreenDismissalEnabledState()
+    const {
+  utils::OptionalVal<bool> empty(utils::OptionalVal<bool>::EMPTY);
+  CACHE_MANAGER_CHECK(empty);
+  sync_primitives::AutoLock auto_lock(cache_lock_);
+  policy_table::ModuleConfig& module_config = pt_->policy_table.module_config;
+  if (module_config.lock_screen_dismissal_enabled.is_initialized()) {
+    return utils::OptionalVal<bool>(
+        *module_config.lock_screen_dismissal_enabled);
+  }
+  return empty;
+}
+
 std::vector<UserFriendlyMessage> CacheManager::GetUserFriendlyMsg(
     const std::vector<std::string>& msg_codes, const std::string& language) {
   LOG4CXX_AUTO_TRACE(logger_);

--- a/src/components/policy/policy_regular/src/policy_manager_impl.cc
+++ b/src/components/policy/policy_regular/src/policy_manager_impl.cc
@@ -987,6 +987,12 @@ void PolicyManagerImpl::KmsChanged(int kilometers) {
   }
 }
 
+const utils::OptionalVal<bool>
+PolicyManagerImpl::LockScreenDismissalEnabledState() const {
+  LOG4CXX_AUTO_TRACE(logger_);
+  return cache_->LockScreenDismissalEnabledState();
+}
+
 void PolicyManagerImpl::IncrementIgnitionCycles() {
   cache_->IncrementIgnitionCycles();
 }

--- a/src/components/policy/policy_regular/src/policy_table/types.cc
+++ b/src/components/policy/policy_regular/src/policy_table/types.cc
@@ -472,7 +472,9 @@ ModuleConfig::ModuleConfig(const Json::Value* value__)
     , vehicle_model(impl::ValueMember(value__, "vehicle_model"))
     , vehicle_year(impl::ValueMember(value__, "vehicle_year"))
     , preloaded_date(impl::ValueMember(value__, "preloaded_date"))
-    , certificate(impl::ValueMember(value__, "certificate")) {}
+    , certificate(impl::ValueMember(value__, "certificate"))
+    , lock_screen_dismissal_enabled(
+          impl::ValueMember(value__, "lock_screen_dismissal_enabled")) {}
 
 void ModuleConfig::SafeCopyFrom(const ModuleConfig& from) {
   //  device_certificates = from.device_certificates;  // According to the
@@ -485,6 +487,8 @@ void ModuleConfig::SafeCopyFrom(const ModuleConfig& from) {
   endpoints = from.endpoints;
   notifications_per_minute_by_priority =
       from.notifications_per_minute_by_priority;
+
+  lock_screen_dismissal_enabled = from.lock_screen_dismissal_enabled;
 
   vehicle_make.assign_if_valid(from.vehicle_make);
   vehicle_model.assign_if_valid(from.vehicle_model);

--- a/src/components/policy/policy_regular/src/sql_pt_queries.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_queries.cc
@@ -71,7 +71,8 @@ const std::string kCreateSchema =
     "  `certificate` TEXT, "
     "  `vehicle_make` VARCHAR(45), "
     "  `vehicle_model` VARCHAR(45), "
-    "  `vehicle_year` VARCHAR(4) "
+    "  `vehicle_year` VARCHAR(4), "
+    "  `lock_screen_dismissal_enabled` BOOL"
     "); "
     "CREATE TABLE IF NOT EXISTS `functional_group`( "
     "  `id` INTEGER PRIMARY KEY NOT NULL, "
@@ -379,7 +380,7 @@ const std::string kInsertInitData =
     "  VALUES (0, 0, 0, 0); "
     "INSERT OR IGNORE INTO `module_config` (`preloaded_pt`, `is_first_run`,"
     "  `exchange_after_x_ignition_cycles`, `exchange_after_x_kilometers`, "
-    "  `exchange_after_x_days`, `timeout_after_x_seconds`) "
+    "  `exchange_after_x_days`, `timeout_after_x_seconds`)"
     "  VALUES(1, 0, 0, 0, 0, 0); "
     "INSERT OR IGNORE INTO `priority`(`value`) VALUES ('EMERGENCY'); "
     "INSERT OR IGNORE INTO `priority`(`value`) VALUES ('NAVIGATION'); "
@@ -617,7 +618,8 @@ const std::string kUpdateModuleConfig =
     "  `exchange_after_x_ignition_cycles` = ?,"
     "  `exchange_after_x_kilometers` = ?, `exchange_after_x_days` = ?, "
     "  `timeout_after_x_seconds` = ?, `certificate` = ?, `vehicle_make` = ?, "
-    "  `vehicle_model` = ?, `vehicle_year` = ? ";
+    "  `vehicle_model` = ?, `vehicle_year` = ?,  lock_screen_dismissal_enabled "
+    "= ?";
 
 const std::string kInsertEndpoint =
     "INSERT INTO `endpoint` (`service`, `url`, `application_id`) "
@@ -657,7 +659,7 @@ const std::string kSelectModuleConfig =
     "SELECT `preloaded_pt`, `exchange_after_x_ignition_cycles`, "
     " `exchange_after_x_kilometers`, `exchange_after_x_days`, "
     " `timeout_after_x_seconds`, `certificate`, `vehicle_make`,"
-    " `vehicle_model`, `vehicle_year` "
+    " `vehicle_model`, `vehicle_year` ,`lock_screen_dismissal_enabled`"
     " FROM `module_config`";
 
 const std::string kSelectEndpoints =
@@ -809,6 +811,5 @@ const std::string kSaveModuleMeta =
     "`ignition_cycles_since_last_exchange` = ? ";
 
 const std::string kSelectModuleMeta = "SELECT* FROM `module_meta`";
-
 }  // namespace sql_pt
 }  // namespace policy

--- a/src/components/policy/policy_regular/src/sql_pt_representation.cc
+++ b/src/components/policy/policy_regular/src/sql_pt_representation.cc
@@ -525,7 +525,9 @@ void SQLPTRepresentation::GatherModuleConfig(
     *config->vehicle_make = query.GetString(6);
     *config->vehicle_model = query.GetString(7);
     *config->vehicle_year = query.GetString(8);
-    *config->preloaded_date = query.GetString(9);
+    if (!query.IsNull(9)) {
+      *config->lock_screen_dismissal_enabled = query.GetBoolean(9);
+    }
   }
 
   utils::dbms::SQLQuery endpoints(db());
@@ -1225,6 +1227,9 @@ bool SQLPTRepresentation::SaveModuleConfig(
                                         : query.Bind(7);
   config.vehicle_year.is_initialized() ? query.Bind(8, *(config.vehicle_year))
                                        : query.Bind(8);
+  config.lock_screen_dismissal_enabled.is_initialized()
+      ? query.Bind(9, *(config.lock_screen_dismissal_enabled))
+      : query.Bind(9);
   if (!query.Exec()) {
     LOG4CXX_WARN(logger_, "Incorrect update module config");
     return false;

--- a/src/components/utils/include/utils/optional.h
+++ b/src/components/utils/include/utils/optional.h
@@ -1,9 +1,14 @@
 #ifndef ERROR_OR_H
 #define ERROR_OR_H
 #include <string>
+#include <memory>
 #include "utils/macro.h"
 
 namespace utils {
+
+class StoragePolicy_CopyValue {};
+
+class StoragePolicy_HandleReference {};
 
 /**
  * @brief The Optional class is able to keep value, manage it it is empty and
@@ -12,11 +17,13 @@ namespace utils {
  * be returned
  *
  */
-template <typename ObjectType, typename ErrorType = std::string>
+template <typename ObjectType,
+          typename ErrorType = std::string,
+          typename StoragePolicy = StoragePolicy_HandleReference>
 class Optional {
  public:
   /**
-   * @brief The OptionalEmpty enum enum with one value to specify that Optional
+   * @brief The OptionalEmpty enum with one value to specify that Optional
    * is not initialized
    */
   enum OptionalEmpty { EMPTY };
@@ -38,7 +45,8 @@ class Optional {
 
   /**
    * @brief Optional constructir without object initialization
-   * @param empty manadatory parameter for explicit specifying that Optional is
+   * @param empty manadotory parameter for explicitly specifying that Optional
+   * is
    * empty
    * @param error error code initialization
    */
@@ -47,7 +55,8 @@ class Optional {
 
   /**
    * @brief Optional empty optional initialization without specifying error code
-   * @param empty manadatory parameter for explicit specifying that Optional is
+   * @param empty manadotory parameter for explicitly specifying that Optional
+   * is
    * empty
    */
   Optional(OptionalEmpty empty)
@@ -79,5 +88,86 @@ class Optional {
   bool is_initialized_;
 };
 
+template <typename ObjectType, typename ErrorType>
+class Optional<ObjectType, ErrorType, StoragePolicy_CopyValue> {
+  typedef Optional<ObjectType, ErrorType, StoragePolicy_CopyValue> ClassName;
+
+ public:
+  /**
+   * @brief The OptionalEmpty enum with one value to specify that Optional
+   * is not initialized
+   */
+  enum OptionalEmpty { EMPTY };
+
+  /**
+   * @brief Copy constructor of Optional
+   */
+  Optional(const ClassName& copy)
+      : object_(copy.is_initialized_ ? new ObjectType(*copy) : nullptr)
+      , error_(copy.error())
+      , is_initialized_(copy) {}
+
+  /**
+   * @brief Optional constructor with object initialization
+   * @param object object to initialize Optional
+   */
+  Optional(const ObjectType& object)
+      : object_(new ObjectType(object)), error_(), is_initialized_(true) {}
+
+  /**
+   * @brief Optional constructor with object and error initialization
+   * @param object object to initialize Optional
+   * @param error error code initialization
+   */
+  Optional(ObjectType& object, ErrorType error)
+      : object_(new ObjectType(object)), error_(error), is_initialized_(true) {}
+
+  /**
+   * @brief Optional constructor without object initialization
+   * @param empty manadotory parameter for explicitly specifying that Optional
+   * is
+   * empty
+   * @param error error code initialization
+   */
+  Optional(OptionalEmpty empty, ErrorType error)
+      : object_(nullptr), error_(error), is_initialized_(false) {}
+
+  /**
+   * @brief Optional empty optional initialization without specifying error code
+   * @param empty manadotory parameter for explicitly specifying that Optional
+   * is
+   * empty
+   */
+  Optional(OptionalEmpty empty)
+      : object_(nullptr), error_(), is_initialized_(false) {}
+
+  /**
+   * @brief operator bool operator for checking if optional is initialized
+   */
+  operator bool() const {
+    return is_initialized_;
+  }
+
+  /**
+   * @brief operator * access to object
+   * @return reference to the handled object
+   */
+  ObjectType& operator*() const {
+    DCHECK(is_initialized_);
+    return *object_;
+  }
+
+  ErrorType error() const {
+    return error_;
+  }
+
+ private:
+  std::unique_ptr<ObjectType> object_;
+  ErrorType error_;
+  bool is_initialized_;
+};
+
+template <typename ObjectType, typename ErrorType = std::string>
+using OptionalVal = Optional<ObjectType, ErrorType, StoragePolicy_CopyValue>;
 }  // utils utils
 #endif  // ERROR_OR_H


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/2134

This PR is **ready** for review.

### Risk
This PR makes **minor** API changes.

### Testing Plan
Tested with scripts from  https://github.com/Ford-Luxoft/sdl_atf_test_scripts/pull/1 

### Summary
Allow a passenger to dismiss the lock screen to improve usability of applications. This re-visited proposal now includes a way for individual OEMs to control this mode via policy updates.

### Changelog


##### Enhancements
 * Optional data type now can keep data by value.

### Tasks Remaining:
- [ ] Ford Review
- [ ] Livio Review

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)