### PR TITLE
Feature/service status update

### DIFF
--- a/src/appMain/life_cycle_impl.cc
+++ b/src/appMain/life_cycle_impl.cc
@@ -103,6 +103,13 @@ bool LifeCycleImpl::StartComponents() {
   app_manager_ =
       new application_manager::ApplicationManagerImpl(profile_, profile_);
 
+  auto service_status_update_handler =
+      std::make_shared<protocol_handler::ServiceStatusUpdateHandler>(
+          app_manager_);
+
+  protocol_handler_->set_service_status_update_handler(
+      service_status_update_handler);
+
   DCHECK(!hmi_handler_);
   hmi_handler_ = new hmi_message_handler::HMIMessageHandlerImpl(profile_);
 

--- a/src/appMain/sdl_preloaded_pt.json
+++ b/src/appMain/sdl_preloaded_pt.json
@@ -43,6 +43,14 @@
                         "FULL",
                         "LIMITED"]
                     },
+                    "OnServiceUpdate": {
+                        "hmi_levels": [
+                            "BACKGROUND",
+                            "FULL",
+                            "LIMITED",
+                            "NONE"
+                        ]
+                    },
                     "AddSubMenu": {
                         "hmi_levels": ["BACKGROUND",
                         "FULL",

--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -89,9 +89,38 @@ class MessageHelper {
       hmi_apis::FunctionID::eType function_id);
 
   /**
+   * @brief CreateOnServiceStatusUpdateNotification creates on status update hmi
+   * notification smart object
+   * @param app_id - application id
+   * @param service_type - enum value representing service_type
+   * @param service_event - enum value representing service update event
+   * @return smart object containing on status update notification
+   */
+  static smart_objects::SmartObjectSPtr CreateOnServiceStatusUpdateNotification(
+      const uint32_t app_id,
+      const hmi_apis::Common_ServiceType::eType service_type,
+      const hmi_apis::Common_ServiceEvent::eType service_event);
+
+  /**
+   * @brief CreateOnServiceStatusUpdateNotification creates on status update hmi
+   * notification smart object
+   * @param app_id - application id
+   * @param service_type - enum value representing service_type
+   * @param service_event - enum value representing service update event
+   * @param service_event_reason - enum value representing service update reason
+   * @return smart object containing on status update notification
+   */
+  static smart_objects::SmartObjectSPtr CreateOnServiceStatusUpdateNotification(
+      const uint32_t app_id,
+      const hmi_apis::Common_ServiceType::eType service_type,
+      const hmi_apis::Common_ServiceEvent::eType service_event,
+      const hmi_apis::Common_ServiceUpdateReason::eType service_update_reason);
+
+  /**
    * @brief Creates request for different interfaces(JSON)
    * @param correlation_id unique ID
-   * @param params Vector of arguments that we need in GetVehicleData request
+   * @param params Vector of arguments that we need in GetVehicleData
+   * request
    * (e.g. gps, odometer, fuel_level)
    */
   static void CreateGetVehicleDataRequest(

--- a/src/components/application_manager/include/application_manager/policies/regular/policy_handler_observer.h
+++ b/src/components/application_manager/include/application_manager/policies/regular/policy_handler_observer.h
@@ -50,6 +50,8 @@ class PolicyHandlerObserver {
 
   virtual void OnPTUFinished(const bool ptu_result) {}
 
+  virtual void OnPTUTimeoutExceeded() {}
+
   virtual ~PolicyHandlerObserver() {}
 };
 }  //  namespace policy

--- a/src/components/application_manager/include/application_manager/smart_object_keys.h
+++ b/src/components/application_manager/include/application_manager/smart_object_keys.h
@@ -526,6 +526,9 @@ extern const char* policyfile;
 extern const char* is_active;
 extern const char* is_deactivated;
 extern const char* event_name;
+extern const char* service_type;
+extern const char* service_event;
+extern const char* reason;
 
 }  // namespace hmi_notification
 

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/on_service_status_update_notification.h
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/include/sdl_rpc_plugin/commands/hmi/on_service_status_update_notification.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2019, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_HMI_ON_SERVICE_STATUS_UPDATE_NOTIFICATION_H_
+#define SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_HMI_ON_SERVICE_STATUS_UPDATE_NOTIFICATION_H_
+
+#include "application_manager/commands/notification_to_hmi.h"
+
+namespace sdl_rpc_plugin {
+namespace app_mngr = application_manager;
+
+namespace commands {
+
+namespace hmi {
+
+/**
+ * @brief OnServiceStatusUpdateNotification command class
+ **/
+class OnServiceStatusUpdateNotification
+    : public app_mngr::commands::NotificationToHMI {
+ public:
+  /**
+   * @brief OnServiceStatusUpdateNotification class constructor
+   * @param application_manager ref to application manager
+   * @param rpc_service ref to rpc service
+   * @param hmi_capabilities ref to HMI capabilities
+   * @param policy_handle ref to policy handler
+   **/
+  OnServiceStatusUpdateNotification(
+      const app_mngr::commands::MessageSharedPtr& message,
+      app_mngr::ApplicationManager& application_manager,
+      app_mngr::rpc_service::RPCService& rpc_service,
+      app_mngr::HMICapabilities& hmi_capabilities,
+      policy::PolicyHandlerInterface& policy_handle);
+
+  /**
+   * @brief OnServiceStatusUpdateNotification class destructor
+   **/
+  virtual ~OnServiceStatusUpdateNotification() OVERRIDE;
+
+  /**
+   * @brief Execute command
+   **/
+  void Run() OVERRIDE;
+
+ private:
+  DISALLOW_COPY_AND_ASSIGN(OnServiceStatusUpdateNotification);
+};
+
+}  // namespace hmi
+
+}  // namespace commands
+
+}  // namespace application_manager
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_RPC_PLUGINS_SDL_RPC_PLUGIN_INCLUDE_SDL_RPC_PLUGIN_COMMANDS_HMI_ON_SERVICE_STATUS_UPDATE_NOTIFICATION_H_

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_service_status_update_notification.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/commands/hmi/on_service_status_update_notification.cc
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2019, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sdl_rpc_plugin/commands/hmi/on_service_status_update_notification.h"
+
+namespace sdl_rpc_plugin {
+using namespace application_manager;
+
+namespace commands {
+
+namespace hmi {
+
+OnServiceStatusUpdateNotification::OnServiceStatusUpdateNotification(
+    const application_manager::commands::MessageSharedPtr& message,
+    ApplicationManager& application_manager,
+    rpc_service::RPCService& rpc_service,
+    HMICapabilities& hmi_capabilities,
+    policy::PolicyHandlerInterface& policy_handle)
+    : NotificationToHMI(message,
+                        application_manager,
+                        rpc_service,
+                        hmi_capabilities,
+                        policy_handle) {}
+
+OnServiceStatusUpdateNotification::~OnServiceStatusUpdateNotification() {}
+
+void OnServiceStatusUpdateNotification::Run() {
+  LOG4CXX_AUTO_TRACE(logger_);
+
+  SendNotification();
+}
+}  // namespace hmi
+}  // namespace commands
+}  // namespace application_manager

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/hmi_command_factory.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/src/hmi_command_factory.cc
@@ -240,6 +240,7 @@
 #include "sdl_rpc_plugin/commands/hmi/rc_is_ready_response.h"
 #include "sdl_rpc_plugin/commands/hmi/rc_get_capabilities_request.h"
 #include "sdl_rpc_plugin/commands/hmi/rc_get_capabilities_response.h"
+#include "sdl_rpc_plugin/commands/hmi/on_service_status_update_notification.h"
 
 namespace sdl_rpc_plugin {
 using namespace application_manager;
@@ -821,6 +822,10 @@ CommandCreator& HMICommandFactory::get_creator_factory(
       return hmi_apis::messageType::request == message_type
                  ? factory.GetCreator<commands::hmi::DialNumberRequest>()
                  : factory.GetCreator<commands::hmi::DialNumberResponse>();
+    }
+    case hmi_apis::FunctionID::BasicCommunication_OnServiceUpdate: {
+      return factory
+          .GetCreator<commands::hmi::OnServiceStatusUpdateNotification>();
     }
     case hmi_apis::FunctionID::Navigation_OnWayPointChange: {
       return factory.GetCreator<commands::OnNaviWayPointChangeNotification>();

--- a/src/components/application_manager/src/application_impl.cc
+++ b/src/components/application_manager/src/application_impl.cc
@@ -507,6 +507,13 @@ void ApplicationImpl::StartStreaming(
     if (!video_streaming_approved()) {
       LOG4CXX_TRACE(logger_, "Video streaming not approved");
       MessageHelper::SendNaviStartStream(app_id(), application_manager_);
+      auto on_service_status_update_notification =
+          MessageHelper::CreateOnServiceStatusUpdateNotification(
+              app_id(),
+              hmi_apis::Common_ServiceType::VIDEO,
+              hmi_apis::Common_ServiceEvent::REQUEST_RECEIVED);
+      application_manager_.GetRPCService().ManageHMICommand(
+          on_service_status_update_notification);
       set_video_stream_retry_number(0);
     }
   } else if (ServiceType::kAudio == service_type) {
@@ -514,6 +521,13 @@ void ApplicationImpl::StartStreaming(
     if (!audio_streaming_approved()) {
       LOG4CXX_TRACE(logger_, "Audio streaming not approved");
       MessageHelper::SendAudioStartStream(app_id(), application_manager_);
+      auto on_service_status_update_notification =
+          MessageHelper::CreateOnServiceStatusUpdateNotification(
+              app_id(),
+              hmi_apis::Common_ServiceType::AUDIO,
+              hmi_apis::Common_ServiceEvent::REQUEST_RECEIVED);
+      application_manager_.GetRPCService().ManageHMICommand(
+          on_service_status_update_notification);
       set_audio_stream_retry_number(0);
     }
   }

--- a/src/components/application_manager/src/hmi_interfaces_impl.cc
+++ b/src/components/application_manager/src/hmi_interfaces_impl.cc
@@ -103,6 +103,8 @@ generate_function_to_interface_convert_map() {
       HmiInterfaces::HMI_INTERFACE_BasicCommunication;
   convert_map[BasicCommunication_OnEventChanged] =
       HmiInterfaces::HMI_INTERFACE_BasicCommunication;
+  convert_map[BasicCommunication_OnServiceUpdate] =
+      HmiInterfaces::HMI_INTERFACE_BasicCommunication;
   convert_map[VR_IsReady] = HmiInterfaces::HMI_INTERFACE_VR;
   convert_map[VR_Started] = HmiInterfaces::HMI_INTERFACE_VR;
   convert_map[VR_Stopped] = HmiInterfaces::HMI_INTERFACE_VR;

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -1990,6 +1990,45 @@ smart_objects::SmartObjectSPtr MessageHelper::CreateNegativeResponse(
   return std::make_shared<smart_objects::SmartObject>(response_data);
 }
 
+smart_objects::SmartObjectSPtr
+MessageHelper::CreateOnServiceStatusUpdateNotification(
+    const uint32_t app_id,
+    const hmi_apis::Common_ServiceType::eType service_type,
+    const hmi_apis::Common_ServiceEvent::eType service_event) {
+  auto on_status_update_notification = CreateHMINotification(
+      hmi_apis::FunctionID::BasicCommunication_OnServiceUpdate);
+
+  if (0 < app_id) {
+    (*on_status_update_notification)[strings::msg_params][strings::app_id] =
+        app_id;
+  }
+
+  (*on_status_update_notification)
+      [strings::msg_params][hmi_notification::service_type] = service_type;
+  (*on_status_update_notification)
+      [strings::msg_params][hmi_notification::service_event] = service_event;
+
+  return on_status_update_notification;
+}
+
+smart_objects::SmartObjectSPtr
+MessageHelper::CreateOnServiceStatusUpdateNotification(
+    const uint32_t app_id,
+    const hmi_apis::Common_ServiceType::eType service_type,
+    const hmi_apis::Common_ServiceEvent::eType service_event,
+    const hmi_apis::Common_ServiceUpdateReason::eType service_update_reason) {
+  auto notification = CreateOnServiceStatusUpdateNotification(
+      app_id, service_type, service_event);
+
+  if (hmi_apis::Common_ServiceUpdateReason::eType::INVALID_ENUM !=
+      service_update_reason) {
+    (*notification)[strings::msg_params][hmi_notification::reason] =
+        service_update_reason;
+  }
+
+  return notification;
+}
+
 void MessageHelper::SendNaviSetVideoConfig(
     int32_t app_id,
     ApplicationManager& app_mngr,

--- a/src/components/application_manager/src/policies/policy_handler.cc
+++ b/src/components/application_manager/src/policies/policy_handler.cc
@@ -1592,6 +1592,11 @@ uint32_t PolicyHandler::TimeoutExchangeMSec() const {
 
 void PolicyHandler::OnExceededTimeout() {
   POLICY_LIB_CHECK_VOID();
+
+  std::for_each(listeners_.begin(),
+                listeners_.end(),
+                std::mem_fn(&PolicyHandlerObserver::OnPTUTimeoutExceeded));
+
   policy_manager_->OnExceededTimeout();
 }
 

--- a/src/components/application_manager/src/smart_object_keys.cc
+++ b/src/components/application_manager/src/smart_object_keys.cc
@@ -484,6 +484,9 @@ const char* policyfile = "policyfile";
 const char* is_active = "isActive";
 const char* is_deactivated = "isDeactivated";
 const char* event_name = "eventName";
+const char* service_type = "serviceType";
+const char* service_event = "serviceEvent";
+const char* reason = "reason";
 }  // namespace hmi_notification
 
 }  // namespace application_manager

--- a/src/components/application_manager/test/include/application_manager/mock_message_helper.h
+++ b/src/components/application_manager/test/include/application_manager/mock_message_helper.h
@@ -308,6 +308,18 @@ class MockMessageHelper {
                void(mobile_apis::ButtonName::eType button,
                     ApplicationSharedPtr application,
                     ApplicationManager& app_mngr));
+  MOCK_METHOD3(CreateOnServiceStatusUpdateNotification,
+               smart_objects::SmartObject(
+                   const uint32_t app_id,
+                   const hmi_apis::Common_ServiceType::eType service_type,
+                   const hmi_apis::Common_ServiceEvent::eType service_event));
+  MOCK_METHOD4(CreateOnServiceStatusUpdateNotification,
+               smart_objects::SmartObject(
+                   const uint32_t app_id,
+                   const hmi_apis::Common_ServiceType::eType service_type,
+                   const hmi_apis::Common_ServiceEvent::eType service_event,
+                   const hmi_apis::Common_ServiceUpdateReason::eType
+                       service_update_reason));
 
   static MockMessageHelper* message_helper_mock();
 };

--- a/src/components/application_manager/test/mock_message_helper.cc
+++ b/src/components/application_manager/test/mock_message_helper.cc
@@ -572,4 +572,24 @@ void MessageHelper::SendUnsubscribeButtonNotification(
       ->SendUnsubscribeButtonNotification(button, application, app_mngr);
 }
 
+smart_objects::SmartObject
+MessageHelper::CreateOnServiceStatusUpdateNotification(
+    const uint32_t app_id,
+    const hmi_apis::Common_ServiceType::eType service_type,
+    const hmi_apis::Common_ServiceEvent::eType service_event) {
+  return MockMessageHelper::message_helper_mock()
+      ->CreateOnStatusUpdateNotification(app_id, service_type, service_event);
+}
+
+smart_objects::SmartObject
+MessageHelper::CreateOnServiceStatusUpdateNotification(
+    const uint32_t app_id,
+    const hmi_apis::Common_ServiceType::eType service_type,
+    const hmi_apis::Common_ServiceEvent::eType service_event,
+    const hmi_apis::Common_ServiceUpdateReason service_update_reason) {
+  return MockMessageHelper::message_helper_mock()
+      ->CreateOnStatusUpdateNotification(
+          app_id, service_type, service_event, service_update_reason);
+}
+
 }  // namespace application_manager

--- a/src/components/include/application_manager/policies/policy_handler_observer.h
+++ b/src/components/include/application_manager/policies/policy_handler_observer.h
@@ -50,6 +50,8 @@ class PolicyHandlerObserver {
 
   virtual void OnPTUFinished(const bool ptu_result) {}
 
+  virtual void OnPTUTimeoutExceeded() {}
+
   virtual ~PolicyHandlerObserver() {}
 };
 }  //  namespace policy

--- a/src/components/include/protocol_handler/protocol_handler.h
+++ b/src/components/include/protocol_handler/protocol_handler.h
@@ -136,6 +136,8 @@ class ProtocolHandler {
       const SessionContext& context,
       std::vector<std::string>& rejected_params) = 0;
 
+  virtual void ProcessFailedPTU() = 0;
+
  protected:
   /**
    * \brief Destructor

--- a/src/components/include/security_manager/security_manager.h
+++ b/src/components/include/security_manager/security_manager.h
@@ -168,6 +168,8 @@ class SecurityManager : public protocol_handler::ProtocolObserver,
    */
   virtual void NotifyListenersOnHandshakeFailed() = 0;
 
+  virtual void ProcessFailedPTU() = 0;
+
   /**
    * @brief Check if policy certificate data is empty
    * @return true if policy certificate data is empty otherwise false

--- a/src/components/include/security_manager/security_manager_listener.h
+++ b/src/components/include/security_manager/security_manager_listener.h
@@ -59,6 +59,8 @@ class SecurityManagerListener {
    */
   virtual void OnCertificateUpdateRequired() = 0;
 
+  virtual void OnPTUFailed() = 0;
+
   /**
    * @brief Get certificate data from policy
    * @param reference to string where to save certificate data

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -3342,6 +3342,42 @@
     </param>
   </struct>
 
+  <enum name="ServiceType">
+    <element name="VIDEO" >
+      <description>Refers to the Video service.</description>
+    </element>
+    <element name="AUDIO" >
+      <description>Refers to the Audio service.</description>
+    </element>
+    <element name="RPC" >
+      <description>Refers to the RPC service.</description>
+    </element>	  
+  </enum>
+
+  <enum name="ServiceEvent">
+    <element name="REQUEST_RECEIVED" >
+      <description>When a request for a Service is received.</description>
+    </element>
+    <element name="REQUEST_ACCEPTED" >
+      <description>When a request for a Service is Accepted.</description>
+    </element>			
+    <element name="REQUEST_REJECTED" >
+      <description>When a request for a Service is Rejected.</description>
+    </element>			
+  </enum>	
+
+  <enum name="ServiceUpdateReason">
+    <element name="PTU_FAILED" >
+      <description>When a Service is rejected because the system was unable to get a required Policy Table Update.</description>
+    </element>
+    <element name="INVALID_CERT" >
+      <description>When a Service is rejected because the security certificate is invalid/expired.</description>
+    </element>			
+    <element name="INVALID_TIME" >
+      <description>When a Service is rejected because the system was unable to get a valid SystemTime from HMI, which is required for certificate authentication.</description>
+    </element>			
+  </enum>	
+
 </interface>
 
 <interface name="Buttons" version="1.3.0" date="2017-07-18">
@@ -3429,6 +3465,26 @@
 </interface>
 
 <interface name="BasicCommunication" version="2.0.0" date="2018-09-05">
+<function name="OnServiceUpdate" messagetype="notification">
+  <description>
+    Must be sent by SDL to HMI when there is an update on status of certain services.
+    Services supported with current version: Video
+  </description>
+  <param name="serviceType" type="Common.ServiceType" mandatory="true">
+    <description>Specifies the service which has been updated.</description>
+  </param>
+  <param name="serviceEvent" type="Common.ServiceEvent" mandatory="false">
+    <description>Specifies service update event.</description>
+  </param>
+  <param name="reason" type="Common.ServiceUpdateReason" mandatory="false">
+    <description>
+      The reason for a service event. Certain events may not have a reason, such as when a service is ACCEPTED (which is the normal expected behavior).
+    </description>
+  </param>
+   <param name="appID" type="Integer" mandatory="false">
+       <description>ID of the application which triggered the update.</description>
+   </param>	
+</function>
     <function name="GetSystemTime" messagetype="request">
       <description>Request from SDL to HMI to obtain current UTC time.</description>
     </function>

--- a/src/components/protocol_handler/CMakeLists.txt
+++ b/src/components/protocol_handler/CMakeLists.txt
@@ -34,6 +34,7 @@ include_directories(
   ${COMPONENTS_DIR}/utils/include/
   ${COMPONENTS_DIR}/protocol_handler/include/
   ${COMPONENTS_DIR}/connection_handler/include/
+  ${CMAKE_BINARY_DIR}/src/components/
   ${LOG4CXX_INCLUDE_DIRECTORY}
   ${BSON_INCLUDE_DIRECTORY}
 )

--- a/src/components/protocol_handler/include/protocol_handler/handshake_handler.h
+++ b/src/components/protocol_handler/include/protocol_handler/handshake_handler.h
@@ -57,7 +57,9 @@ class HandshakeHandler : public security_manager::SecurityManagerListener {
                    utils::SemanticVersion& full_version,
                    const SessionContext& context,
                    const uint8_t protocol_version,
-                   std::shared_ptr<BsonObject> payload);
+                   std::shared_ptr<BsonObject> payload,
+                   std::shared_ptr<ServiceStatusUpdateHandler>
+                       service_status_update_handler);
 
   ~HandshakeHandler();
 
@@ -89,6 +91,8 @@ class HandshakeHandler : public security_manager::SecurityManagerListener {
    */
   void OnCertificateUpdateRequired() OVERRIDE;
 
+  void OnPTUFailed() OVERRIDE;
+
   /**
    * @brief Get connection key of this handler
    * @return connection key
@@ -116,6 +120,7 @@ class HandshakeHandler : public security_manager::SecurityManagerListener {
   utils::SemanticVersion full_version_;
   const uint8_t protocol_version_;
   std::shared_ptr<BsonObject> payload_;
+  std::shared_ptr<ServiceStatusUpdateHandler> service_status_update_handler_;
 };
 
 }  // namespace protocol_handler

--- a/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
+++ b/src/components/protocol_handler/include/protocol_handler/protocol_handler_impl.h
@@ -60,6 +60,7 @@
 #include "transport_manager/transport_adapter/transport_adapter.h"
 #include "connection_handler/connection_handler.h"
 #include "application_manager/policies/policy_handler_observer.h"
+#include "protocol_handler/service_status_update_handler.h"
 
 #ifdef TELEMETRY_MONITOR
 #include "protocol_handler/telemetry_observer.h"
@@ -205,6 +206,8 @@ class ProtocolHandlerImpl
 
   void RemoveProtocolObserver(ProtocolObserver* observer) OVERRIDE;
 
+  void ProcessFailedPTU() OVERRIDE;
+
 #ifdef ENABLE_SECURITY
   /**
    * \brief Sets pointer for SecurityManager layer for managing protection
@@ -214,6 +217,9 @@ class ProtocolHandlerImpl
   void set_security_manager(
       security_manager::SecurityManager* security_manager);
 #endif  // ENABLE_SECURITY
+
+  void set_service_status_update_handler(
+      std::shared_ptr<ServiceStatusUpdateHandler> handler);
 
   /**
    * \brief Stop all handling activity
@@ -772,6 +778,8 @@ class ProtocolHandlerImpl
 
   sync_primitives::Lock start_session_frame_map_lock_;
   StartSessionFrameMap start_session_frame_map_;
+
+  std::shared_ptr<ServiceStatusUpdateHandler> service_status_update_handler_;
 
   bool tcp_enabled_;
   std::string tcp_port_;

--- a/src/components/protocol_handler/include/protocol_handler/service_status_update_handler.h
+++ b/src/components/protocol_handler/include/protocol_handler/service_status_update_handler.h
@@ -1,0 +1,92 @@
+/*
+ Copyright (c) 2019, Ford Motor Company
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following
+ disclaimer in the documentation and/or other materials provided with the
+ distribution.
+
+ Neither the name of the Ford Motor Company nor the names of its contributors
+ may be used to endorse or promote products derived from this software
+ without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_PROTOCOL_HANDLER_INCLUDE_PROTOCOL_HANDLER_SERVICE_STATUS_UPDATE_HANDLER_H_
+#define SRC_COMPONENTS_PROTOCOL_HANDLER_INCLUDE_PROTOCOL_HANDLER_SERVICE_STATUS_UPDATE_HANDLER_H_
+
+#include "protocol_handler/service_status_update_handler_listener.h"
+
+namespace protocol_handler {
+
+/**
+  * @brief  ServiceUpdateFailureReason helper enum containing reasons for
+  *service
+  * status to be updated
+  **/
+enum class ServiceStatus {
+  INVALID_ENUM = -1,
+  SERVICE_RECEIVED,
+  SERVICE_ACCEPTED,
+  SERVICE_START_FAILED,
+  PTU_FAILED,
+  CERT_INVALID,
+  INVALID_TIME
+};
+
+/**
+ * @brief ServiceStatusUpdateHandler class is used to notify listeners about
+ * occured events during service start
+ **/
+class ServiceStatusUpdateHandler {
+ public:
+  /**
+  * @brief ServiceStatusUpdateHandler class constructor
+  * @param listener pointer to ServiceStatusUpdateHandlerListener instance
+  **/
+  ServiceStatusUpdateHandler(ServiceStatusUpdateHandlerListener* listener)
+      : listener_(listener) {}
+
+  /**
+   * @brief OnServiceUpdate callback that is invoked in case of
+   * service status update needed
+   * @param connection_key - connection key
+   * @param service_type enum value containing type of service.
+   * @param service_status enum value containing status of service.
+   * received
+   **/
+  void OnServiceUpdate(const uint32_t connection_key,
+                       const protocol_handler::ServiceType service_type,
+                       const ServiceStatus service_status);
+
+  /**
+   * @brief set_listener sets listener to ServiceStatusUpdateHandler
+   * @param listener pointer to ServiceStatusUpdateHandlerListener instance
+   **/
+  void set_listener(const ServiceStatusUpdateHandlerListener* listener);
+
+ private:
+  ServiceStatusUpdateHandlerListener* listener_;
+};
+
+}  // namespace protocol_handler
+
+#endif  // SRC_COMPONENTS_APPLICATION_MANAGER_INCLUDE_APPLICATION_MANAGER_SERVICE_STATUS_UPDATE_HANDLER_H_

--- a/src/components/protocol_handler/include/protocol_handler/service_status_update_handler_listener.h
+++ b/src/components/protocol_handler/include/protocol_handler/service_status_update_handler_listener.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2019, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SRC_COMPONENTS_PROTOCOL_HANDLER_INCLUDE_PROTOCOL_HANDLER_SERVICE_STATUS_UPDATE_HANDLER_LISTENER_H_
+#define SRC_COMPONENTS_PROTOCOL_HANDLER_INCLUDE_PROTOCOL_HANDLER_SERVICE_STATUS_UPDATE_HANDLER_LISTENER_H_
+
+#include "interfaces/HMI_API.h"
+#include "protocol_handler/protocol_handler.h"
+#include "transport_manager/transport_manager.h"
+
+namespace protocol_handler {
+/**
+ * @brief Converts service type enum value from protocol_handler to hmi_apis.
+ * @param service_type protocol_handler enum value.
+ **/
+hmi_apis::Common_ServiceType::eType GetHMIServiceType(
+    protocol_handler::ServiceType service_type);
+
+/**
+  * @brief ServiceStatusUpdateHandlerListener provides callbacks interface with
+  * a purpose to notify HMI on successful or failed state updates of different
+  * services
+  **/
+class ServiceStatusUpdateHandlerListener {
+ public:
+  /**
+   * @brief ProcessServiceStatusUpdate callback that is invoked in case of
+   * service
+   * status update
+   * @param connection_key - connection key
+   * @param service_type enum value containing type of service.
+   * @param service_event enum value containing event that occured during
+   * service start.
+   * @param service_update_reason enum value containing reason why service_event
+   * occured.
+   **/
+  virtual void ProcessServiceStatusUpdate(
+      const uint32_t connection_key,
+      hmi_apis::Common_ServiceType::eType service_type,
+      hmi_apis::Common_ServiceEvent::eType service_event,
+      hmi_apis::Common_ServiceUpdateReason::eType service_update_reason) = 0;
+};
+
+}  // namespace protocol_handler
+
+#endif

--- a/src/components/protocol_handler/src/handshake_handler.cc
+++ b/src/components/protocol_handler/src/handshake_handler.cc
@@ -43,18 +43,21 @@ namespace protocol_handler {
 
 CREATE_LOGGERPTR_GLOBAL(logger_, "ProtocolHandler")
 
-HandshakeHandler::HandshakeHandler(ProtocolHandlerImpl& protocol_handler,
-                                   SessionObserver& session_observer,
-                                   utils::SemanticVersion& full_version,
-                                   const SessionContext& context,
-                                   const uint8_t protocol_version,
-                                   std::shared_ptr<BsonObject> payload)
+HandshakeHandler::HandshakeHandler(
+    ProtocolHandlerImpl& protocol_handler,
+    SessionObserver& session_observer,
+    utils::SemanticVersion& full_version,
+    const SessionContext& context,
+    const uint8_t protocol_version,
+    std::shared_ptr<BsonObject> payload,
+    std::shared_ptr<ServiceStatusUpdateHandler> service_status_update_handler)
     : protocol_handler_(protocol_handler)
     , session_observer_(session_observer)
     , context_(context)
     , full_version_(full_version)
     , protocol_version_(protocol_version)
-    , payload_(payload) {}
+    , payload_(payload)
+    , service_status_update_handler_(service_status_update_handler) {}
 
 HandshakeHandler::~HandshakeHandler() {
   LOG4CXX_DEBUG(logger_, "Destroying of HandshakeHandler: " << this);
@@ -72,6 +75,10 @@ bool HandshakeHandler::GetPolicyCertificateData(std::string& data) const {
 void HandshakeHandler::OnCertificateUpdateRequired() {}
 
 bool HandshakeHandler::OnHandshakeFailed() {
+  service_status_update_handler_->OnServiceUpdate(this->connection_key(),
+                                                  context_.service_type_,
+                                                  ServiceStatus::INVALID_TIME);
+
   if (payload_) {
     ProcessFailedHandshake(*payload_);
   } else {
@@ -82,6 +89,12 @@ bool HandshakeHandler::OnHandshakeFailed() {
   }
 
   return true;
+}
+
+void HandshakeHandler::OnPTUFailed() {
+  service_status_update_handler_->OnServiceUpdate(this->connection_key(),
+                                                  context_.service_type_,
+                                                  ServiceStatus::PTU_FAILED);
 }
 
 bool HandshakeHandler::OnHandshakeDone(
@@ -101,6 +114,11 @@ bool HandshakeHandler::OnHandshakeDone(
 
   const bool success =
       result == security_manager::SSLContext::Handshake_Result_Success;
+
+  const auto service_status =
+      success ? ServiceStatus::SERVICE_ACCEPTED : ServiceStatus::CERT_INVALID;
+  service_status_update_handler_->OnServiceUpdate(
+      this->connection_key(), context_.service_type_, service_status);
 
   if (payload_) {
     if (success) {

--- a/src/components/protocol_handler/src/service_status_update_handler.cc
+++ b/src/components/protocol_handler/src/service_status_update_handler.cc
@@ -1,0 +1,74 @@
+#include "protocol_handler/service_status_update_handler.h"
+#include "interfaces/HMI_API.h"
+
+namespace protocol_handler {
+
+hmi_apis::Common_ServiceType::eType GetHMIServiceType(
+    protocol_handler::ServiceType service_type) {
+  using namespace hmi_apis;
+  using namespace protocol_handler;
+  switch (service_type) {
+    case SERVICE_TYPE_RPC: {
+      return Common_ServiceType::RPC;
+    }
+    case SERVICE_TYPE_AUDIO: {
+      return Common_ServiceType::AUDIO;
+    }
+    case SERVICE_TYPE_NAVI: {
+      return Common_ServiceType::VIDEO;
+    }
+    default: { 
+      return Common_ServiceType::INVALID_ENUM; 
+    }
+  }
+}
+
+void ServiceStatusUpdateHandler::OnServiceUpdate(
+    const uint32_t connection_key,
+    const protocol_handler::ServiceType service_type,
+    ServiceStatus service_status) {
+  using namespace hmi_apis;
+  auto hmi_service_type = GetHMIServiceType(service_type);
+  Common_ServiceEvent::eType service_event;
+  Common_ServiceUpdateReason::eType service_update_reason;
+
+  switch (service_status) {
+    case ServiceStatus::SERVICE_RECEIVED: {
+      service_event = Common_ServiceEvent::REQUEST_RECEIVED;
+      service_update_reason = Common_ServiceUpdateReason::INVALID_ENUM;
+      break;
+    }
+    case ServiceStatus::SERVICE_ACCEPTED: {
+      service_event = Common_ServiceEvent::REQUEST_ACCEPTED;
+      service_update_reason = Common_ServiceUpdateReason::INVALID_ENUM;
+      break;
+    }
+    case ServiceStatus::SERVICE_START_FAILED: {
+      service_event = Common_ServiceEvent::REQUEST_REJECTED;
+      service_update_reason = Common_ServiceUpdateReason::INVALID_ENUM;
+      break;
+    }
+    case ServiceStatus::PTU_FAILED: {
+      service_event = Common_ServiceEvent::REQUEST_REJECTED;
+      service_update_reason = Common_ServiceUpdateReason::PTU_FAILED;
+      break;
+    }
+    case ServiceStatus::CERT_INVALID: {
+      service_event = Common_ServiceEvent::REQUEST_REJECTED;
+      service_update_reason = Common_ServiceUpdateReason::INVALID_CERT;
+      break;
+    }
+    case ServiceStatus::INVALID_TIME: {
+      service_event = Common_ServiceEvent::REQUEST_REJECTED;
+      service_update_reason = Common_ServiceUpdateReason::INVALID_TIME;
+      break;
+    }
+    default: { 
+      return; 
+    }
+  }
+
+  listener_->ProcessServiceStatusUpdate(
+      connection_key, hmi_service_type, service_event, service_update_reason);
+}
+}  // namespace protocol_handler

--- a/src/components/security_manager/include/security_manager/security_manager_impl.h
+++ b/src/components/security_manager/include/security_manager/security_manager_impl.h
@@ -214,6 +214,8 @@ class SecurityManagerImpl : public SecurityManager,
    */
   static const char* ConfigSection();
 
+  void ProcessFailedPTU() OVERRIDE;
+
  private:
   /**
    * \brief Sends Handshake binary data to mobile application

--- a/src/components/security_manager/src/security_manager_impl.cc
+++ b/src/components/security_manager/src/security_manager_impl.cc
@@ -388,6 +388,17 @@ void SecurityManagerImpl::OnSystemTimeArrived(const time_t utc_time) {
   awaiting_time_connections_.clear();
 }
 
+void SecurityManagerImpl::ProcessFailedPTU() {
+  LOG4CXX_AUTO_TRACE(logger_);
+  if (listeners_.empty()) {
+    LOG4CXX_ERROR(logger_, "listeners arrays IS EMPTY!");
+    return;
+  }
+  std::for_each(listeners_.begin(),
+                listeners_.end(),
+                std::mem_fun(&SecurityManagerListener::OnPTUFailed));
+}
+
 void SecurityManagerImpl::NotifyListenersOnHandshakeDone(
     const uint32_t& connection_key, SSLContext::HandshakeResult error) {
   LOG4CXX_AUTO_TRACE(logger_);


### PR DESCRIPTION
Implements #2791

This PR is **[ready]** for review.

### Risk
This PR makes **[minor]** API changes.

### Testing Plan
Unit tests
ATF tests

### Summary
Added ServiceStatusUpdateHandler and ServiceStatusUpdateHandlerListener interface to dispatch OnServiceUpdate notifications depending on handshake status.

[ServiceStatusUpdate_classes.pdf](https://github.com/Ford-Luxoft/sdl_core/files/2791518/ServiceStatusUpdate_classes.pdf)

[ServiceStatusUpdate_sequence.pdf.pdf](https://github.com/Ford-Luxoft/sdl_core/files/2791519/ServiceStatusUpdate_sequence.pdf.pdf)




### Tasks Remaining:
- [ ] Unit tests
- [ ] ATF tests
- [ ] Bugfix
- [ ] Clean up (remove duplications, remove redundant code)

### CLA
- [ ] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)