### PR TITLE
Feature/Remote control radio and climate parameter update

### DIFF
--- a/src/appMain/hmi_capabilities.json
+++ b/src/appMain/hmi_capabilities.json
@@ -428,6 +428,7 @@
                         "acMaxEnableAvailable": true,
                         "autoModeEnableAvailable": true,
                         "circulateAirEnableAvailable": true,
+                        "climateEnableAvailable": true,
                         "currentTemperatureAvailable": true,
                         "defrostZone": [
                             "FRONT",
@@ -455,7 +456,7 @@
                 ],
                 "radioControlCapabilities": [
                     {
-                        "availableHDsAvailable": true,
+                        "availableHdChannelsAvailable": true,
                         "hdChannelAvailable": true,
                         "moduleName": "radio",
                         "radioBandAvailable": true,

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_module_constants.h
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/include/rc_rpc_plugin/rc_module_constants.h
@@ -151,7 +151,7 @@ const char kFrequencyFraction[] = "frequencyFraction";
 const char kBand[] = "band";
 const char kRdsData[] = "rdsData";
 const char kHdRadioEnable[] = "hdRadioEnable";
-const char kAvailableHDs[] = "availableHDs";
+const char kAvailableHdChannels[] = "availableHdChannels";
 const char kHdChannel[] = "hdChannel";
 const char kSignalStrength[] = "signalStrength";
 const char kSignalChangeThreshold[] = "signalChangeThreshold";
@@ -176,6 +176,8 @@ const char kHeatedSteeringWheelEnable[] = "heatedSteeringWheelEnable";
 const char kHeatedWindshieldEnable[] = "heatedWindshieldEnable";
 const char kHeatedRearWindowEnable[] = "heatedRearWindowEnable";
 const char kHeatedMirrorsEnable[] = "heatedMirrorsEnable";
+const char kClimateEnable[] = "climateEnable";
+const char kClimateEnableAvailable[] = "climateEnableAvailable";
 // ClimateControlData struct
 
 // LightControlData

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/get_interior_vehicle_data_request.cc
@@ -108,7 +108,7 @@ void GetInteriorVehicleDataRequest::FilterDisabledModuleData(
   if (module_data.keyExists(message_params::kHdRadioEnable) &&
       module_data[message_params::kHdRadioEnable].asBool() == false) {
     module_data.erase(message_params::kHdChannel);
-    module_data.erase(message_params::kAvailableHDs);
+    module_data.erase(message_params::kAvailableHdChannels);
     module_data.erase(message_params::kSisData);
   }
 }

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_request.cc
@@ -54,7 +54,7 @@ std::vector<std::string> GetModuleReadOnlyParams(
     module_ro_params.push_back(kCurrentTemperature);
   } else if (enums_value::kRadio == module_type) {
     module_ro_params.push_back(kRdsData);
-    module_ro_params.push_back(kAvailableHDs);
+    module_ro_params.push_back(kAvailableHdChannels);
     module_ro_params.push_back(kSignalStrength);
     module_ro_params.push_back(kSignalChangeThreshold);
     module_ro_params.push_back(kState);
@@ -92,14 +92,16 @@ const std::map<std::string, std::string> GetModuleDataToCapabilitiesMapping() {
   mapping["heatedWindshieldEnable"] = "heatedWindshieldAvailable";
   mapping["heatedMirrorsEnable"] = "heatedMirrorsAvailable";
   mapping["heatedRearWindowEnable"] = "heatedRearWindowAvailable";
+  mapping["climateEnable"] = "climateEnable";
+  mapping["climateEnableAvailable"] = "climateEnableAvailable";
 
   // radio
   mapping["band"] = "radioBandAvailable";
   mapping["frequencyInteger"] = "radioFrequencyAvailable";
   mapping["frequencyFraction"] = "radioFrequencyAvailable";
   mapping["rdsData"] = "rdsDataAvailable";
-  mapping["availableHDs"] = "availableHDsAvailable";
-  mapping["hdChannel"] = "availableHDsAvailable";
+  mapping["availableHdChannels"] = "availableHdChannelsAvailable";
+  mapping["hdChannel"] = "availableHdChannelsAvailable";
   mapping["hdRadioEnable"] = "hdRadioEnableAvailable";
   mapping["signalStrength"] = "signalStrengthAvailable";
   mapping["signalChangeThreshold"] = "signalChangeThresholdAvailable";

--- a/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_request.cc
+++ b/src/components/application_manager/rpc_plugins/rc_rpc_plugin/src/commands/mobile/set_interior_vehicle_data_request.cc
@@ -92,7 +92,7 @@ const std::map<std::string, std::string> GetModuleDataToCapabilitiesMapping() {
   mapping["heatedWindshieldEnable"] = "heatedWindshieldAvailable";
   mapping["heatedMirrorsEnable"] = "heatedMirrorsAvailable";
   mapping["heatedRearWindowEnable"] = "heatedRearWindowAvailable";
-  mapping["climateEnable"] = "climateEnable";
+  mapping["climateEnable"] = "climateEnableAvailable";
   mapping["climateEnableAvailable"] = "climateEnableAvailable";
 
   // radio

--- a/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/rc_get_capabilities_response_test.cc
+++ b/src/components/application_manager/rpc_plugins/sdl_rpc_plugin/test/commands/hmi/rc_get_capabilities_response_test.cc
@@ -138,7 +138,7 @@ TEST_F(RCGetCapabilitiesResponseTest, RUN_SUCCESSS) {
   radio_control_capability["radioFrequencyAvailable"] = true;
   radio_control_capability["hdChannelAvailable"] = true;
   radio_control_capability["rdsDataAvailable"] = true;
-  radio_control_capability["availableHDsAvailable"] = true;
+  radio_control_capability["availableHdChannelsAvailable"] = true;
   radio_control_capability["stateAvailable"] = true;
   radio_control_capability["signalStrengthAvailable"] = true;
   radio_control_capability["signalChangeThresholdAvailable"] = true;

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1864,7 +1864,7 @@
    <param name="availableHdChannels" type="Integer" minvalue="0" maxvalue="7" array="true" minsize="0" maxsize="8" mandatory="false">
      <description>The list of available hd sub-channel indexes. Empty list means no Hd channel is available. Read-only.</description>
    </param>
-   <param name="hdChannel" type="Integer" minvalue="1" maxvalue="7" mandatory="false">
+   <param name="hdChannel" type="Integer" minvalue="0" maxvalue="7" mandatory="false">
      <description>Current HD sub-channel if available</description>
    </param>
    <param name="signalStrength" type="Integer" minvalue="0" maxvalue="100" mandatory="false">

--- a/src/components/interfaces/HMI_API.xml
+++ b/src/components/interfaces/HMI_API.xml
@@ -1861,8 +1861,8 @@
    <param name="hdRadioEnable" type="Boolean" mandatory="false">
      <description> True if the hd radio is on, false is the radio is off</description>
    </param>
-   <param name="availableHDs" type="Integer" minvalue="1" maxvalue="7" mandatory="false">
-     <description>number of HD sub-channels if available</description>
+   <param name="availableHdChannels" type="Integer" minvalue="0" maxvalue="7" array="true" minsize="0" maxsize="8" mandatory="false">
+     <description>The list of available hd sub-channel indexes. Empty list means no Hd channel is available. Read-only.</description>
    </param>
    <param name="hdChannel" type="Integer" minvalue="1" maxvalue="7" mandatory="false">
      <description>Current HD sub-channel if available</description>
@@ -1917,9 +1917,9 @@
        True: Available, False: Not Available, Not present: Not Available.
      </description>
    </param>
-   <param name="availableHDsAvailable" type="Boolean" mandatory="false" >
+   <param name="availableHdChannelsAvailable" type="Boolean" mandatory="false">
      <description>
-       Availability of the getting the number of available HD channels.
+       Availability of the list of available HD sub-channel indexes.
        True: Available, False: Not Available, Not present: Not Available.
      </description>
    </param>
@@ -2022,6 +2022,8 @@
    <param name="heatedMirrorsEnable" type="Boolean" mandatory="false">
        <description>value false means disabled, value true means enabled.</description>
    </param>
+   <param name="climateEnable" type="Boolean" mandatory="false" since="5.1">
+   </param>
  </struct>
 
    <struct name="ClimateControlCapabilities">
@@ -2120,6 +2122,12 @@
    <param name="heatedMirrorsAvailable" type="Boolean" mandatory="false">
        <description>
          Availability of the control (enable/disable) of heated Mirrors.
+         True: Available, False: Not Available, Not present: Not Available.
+       </description>
+   </param>
+   <param name="climateEnableAvailable" type="Boolean" mandatory="false">
+       <description>
+         Availability of the control of enable/disable climate control.
          True: Available, False: Not Available, Not present: Not Available.
        </description>
    </param>

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -3060,16 +3060,21 @@
         <param name="hdRadioEnable" type="Boolean" mandatory="false"  since="5.0">
             <description> True if the hd radio is on, false if the radio is off</description>
         </param>
-        <param name="availableHDs" type="Integer" minvalue="1" maxvalue="7" mandatory="false" since="5.0">
-            <description>number of HD sub-channels if available</description>
+        <param name="availableHDs" type="Integer" minvalue="0" maxvalue="7" mandatory="false" deprecated="true" since="5.1">
+            <description>Number of HD sub-channels if available</description>
             <history>
                 <param name="availableHDs" type="Integer" minvalue="1" maxvalue="3" mandatory="false" since="4.5" until="5.0"/>
+                <param name="availableHDs" type="Integer" minvalue="0" maxvalue="7" mandatory="false" since="5.0" until="5.1"/>
             </history>
         </param>
-        <param name="hdChannel" type="Integer" minvalue="1" maxvalue="7" mandatory="false" since="5.0">
+        <param name="availableHdChannels" type="Integer" minvalue="0" maxvalue="7" array="true" minsize="0" maxsize="8" mandatory="false" since="5.1">
+            <description>The list of available HD sub-channel indexes. Empty list means no Hd channel is available. Read-only. </description>
+        </param>
+        <param name="hdChannel" type="Integer" minvalue="0" maxvalue="7" mandatory="false" since="5.1">
             <description>Current HD sub-channel if available</description>
             <history>
                 <param name="hdChannel" type="Integer" minvalue="1" maxvalue="3" mandatory="false" since="4.5" until="5.0"/>
+                <param name="hdChannel" type="Integer" minvalue="1" maxvalue="7" mandatory="false" since="5.0" until="5.1"/>
             </history>
         </param>
         <param name="signalStrength" type="Integer" minvalue="0" maxvalue="100" mandatory="false">
@@ -3120,6 +3125,8 @@
         <param name="heatedMirrorsEnable" type="Boolean" mandatory="false" since="5.0">
             <description>value false means disabled, value true means enabled.</description>
         </param>
+        <param name="climateEnable" type="Boolean" mandatory="false" since="5.1">
+        </param>
     </struct>
 
     <struct name="RadioControlCapabilities" since="4.5">
@@ -3161,9 +3168,18 @@
                 True: Available, False: Not Available, Not present: Not Available.
             </description>
         </param>
-        <param name="availableHDsAvailable" type="Boolean" mandatory="false">
+        <param name="availableHDsAvailable" type="Boolean" mandatory="false" deprecated="true" since="5.1">
             <description>
                 Availability of the getting the number of available HD channels.
+                True: Available, False: Not Available, Not present: Not Available.
+            </description>
+            <history>
+                <param name="availableHDsAvailable" type="Boolean" mandatory="false" since="1.0" until="5.1"/>
+            </history>
+        </param>
+        <param name="availableHdChannelsAvailable" type="Boolean" mandatory="false" since="5.1">
+            <description>
+                Availability of the list of available HD sub-channel indexes.
                 True: Available, False: Not Available, Not present: Not Available.
             </description>
         </param>
@@ -3303,6 +3319,12 @@
         <param name="heatedMirrorsAvailable" type="Boolean" mandatory="false" since="5.0">
             <description>
                 Availability of the control (enable/disable) of heated Mirrors.
+                True: Available, False: Not Available, Not present: Not Available.
+            </description>
+        </param>
+        <param name="climateEnableAvailable" type="Boolean" mandatory="false" since="5.1">
+            <description>
+                Availability of the control of enable/disable climate control.
                 True: Available, False: Not Available, Not present: Not Available.
             </description>
         </param>

--- a/src/components/interfaces/MOBILE_API.xml
+++ b/src/components/interfaces/MOBILE_API.xml
@@ -3067,10 +3067,10 @@
                 <param name="availableHDs" type="Integer" minvalue="0" maxvalue="7" mandatory="false" since="5.0" until="5.1"/>
             </history>
         </param>
-        <param name="availableHdChannels" type="Integer" minvalue="0" maxvalue="7" array="true" minsize="0" maxsize="8" mandatory="false" since="5.1">
+        <param name="availableHdChannels" type="Integer" minvalue="0" maxvalue="7" array="true" minsize="0" maxsize="8" mandatory="false" since="5.0">
             <description>The list of available HD sub-channel indexes. Empty list means no Hd channel is available. Read-only. </description>
         </param>
-        <param name="hdChannel" type="Integer" minvalue="0" maxvalue="7" mandatory="false" since="5.1">
+        <param name="hdChannel" type="Integer" minvalue="0" maxvalue="7" mandatory="false" since="5.0">
             <description>Current HD sub-channel if available</description>
             <history>
                 <param name="hdChannel" type="Integer" minvalue="1" maxvalue="3" mandatory="false" since="4.5" until="5.0"/>
@@ -3168,7 +3168,7 @@
                 True: Available, False: Not Available, Not present: Not Available.
             </description>
         </param>
-        <param name="availableHDsAvailable" type="Boolean" mandatory="false" deprecated="true" since="5.1">
+        <param name="availableHDsAvailable" type="Boolean" mandatory="false" deprecated="true" since="5.0">
             <description>
                 Availability of the getting the number of available HD channels.
                 True: Available, False: Not Available, Not present: Not Available.
@@ -3177,7 +3177,7 @@
                 <param name="availableHDsAvailable" type="Boolean" mandatory="false" since="1.0" until="5.1"/>
             </history>
         </param>
-        <param name="availableHdChannelsAvailable" type="Boolean" mandatory="false" since="5.1">
+        <param name="availableHdChannelsAvailable" type="Boolean" mandatory="false" since="5.0">
             <description>
                 Availability of the list of available HD sub-channel indexes.
                 True: Available, False: Not Available, Not present: Not Available.


### PR DESCRIPTION
This PR is **ready** for review.

### Risk
This PR makes **major** API changes.

### Summary
SDL remote control shall allow a mobile application to know which HD
sub-channel index has a signal, so that the app can tune the HD radio
to that sub-channel successfully.
According to this motivation, "availableHDs" parameter of RadioControlData
structure marks as deprecated since 5.1 API version and add new parameter
"availableHdChannels" that is a collection of available HD radio channels.
This parameter will be available since 5.1 API version.
Also "availableHDsAvailable" parameter of RadioControlCapabilities
structure marks as deprecated since 5.1 API version and add new parameter
"availableHdChannelsAvailable" that will be available since 5.1 API
version.

SDL remote control shall allow a mobile application to turn the climate
control on or off if the vehicle supports it.
According to this motivation, "climateEnable" parameter add to
ClimateControlData structure. Also "climateEnableAvailable" parameter add
to ClimateControlCapabilities structure.
NOTE: Please, pay attention, API version of deprecated parameters was downgrade for correct manual and auto testing.

### Changelog
**Breaking Changes**

**In RadioControlData:**
- Parameter "availableHDs" mark as deprecated since API version 5.1.
- Parameter "hdChannel" changes his minvalue from 1 to 0.
- Add new parameter  "availableHdChannels" as list of available HD sub-channel indexes, that will be able since API version 5.1.

**In RadioControlCapabilities**:
- Add new parameter "availableHdChannelsAvailable" that will able since API version 5.1.

**In ClimateControlCapabilities:**
- Add new parameter "climateEnableAvailable", that will be able since API version 5.1;

**In ClimateControlData:**
- Add new parameter "climateEnable", that will be able since API version 5.1.

**Other parts of delivery:**
CI activities: http://opensdl-jenkins.luxoft.com:8080/view/remote_control_radio_and_climate_parameter_update/
HMI Integration guidelines: https://github.com/Ford-Luxoft/sdl_hmi_integration_guidelines/pull/4
SDL requirements: https://github.com/smartdevicelink/sdl_requirements/issues/118
ATF scripts: https://github.com/Ford-Luxoft/sdl_atf_test_scripts/pull/5
HMI: https://github.com/Ford-Luxoft/sdl_hmi/pull/8

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
