### PR TITLE
Fix Uts behavior for qnx7

### DIFF
--- a/src/components/hmi_message_handler/test/hmi_message_handler_impl_test.cc
+++ b/src/components/hmi_message_handler/test/hmi_message_handler_impl_test.cc
@@ -60,7 +60,7 @@ class HMIMessageHandlerImplTest : public ::testing::Test {
 
   testing::NiceMock<MockHMIMessageHandlerSettings>
       mock_hmi_message_handler_settings;
-  const uint64_t stack_size = 1000u;
+  const uint64_t stack_size = 8192u;
 
   virtual void SetUp() OVERRIDE {
     ON_CALL(mock_hmi_message_handler_settings, thread_min_stack_size())

--- a/src/components/include/test/utils/test_async_waiter.h
+++ b/src/components/include/test/utils/test_async_waiter.h
@@ -85,9 +85,11 @@ class TestAsyncWaiter {
    * Notifies async waiter
    */
   void Notify() {
-    sync_primitives::AutoLock auto_lock(lock_);
-    notified_ = true;
-    ++count_;
+    {
+      sync_primitives::AutoLock auto_lock(lock_);
+      notified_ = true;
+      ++count_;
+    }
     cond_var_.Broadcast();
   }
 

--- a/src/components/include/utils/threads/message_loop_thread.h
+++ b/src/components/include/utils/threads/message_loop_thread.h
@@ -147,9 +147,8 @@ MessageLoopThread<Q>::MessageLoopThread(const std::string& name,
 
 template <class Q>
 MessageLoopThread<Q>::~MessageLoopThread() {
-  Shutdown();
-  delete thread_delegate_;
   threads::DeleteThread(thread_);
+  delete thread_delegate_;
 }
 
 template <class Q>

--- a/src/components/include/utils/threads/thread.h
+++ b/src/components/include/utils/threads/thread.h
@@ -91,13 +91,12 @@ class Thread {
   PlatformThreadHandle handle_;
   ThreadOptions thread_options_;
   // Should be locked to protect isThreadRunning_ and thread_created_ values
+  sync_primitives::Lock run_lock_;
   sync_primitives::Lock state_lock_;
   volatile unsigned int isThreadRunning_;
   volatile bool stopped_;
   volatile bool finalized_;
   bool thread_created_;
-  // Signalled when Thread::start() is called
-  sync_primitives::ConditionalVariable run_cond_;
 
  public:
   static int count;


### PR DESCRIPTION
This PR is **ready** for review.  
This PR includes implementation for  proposal [Porting SDL to QNX700 and Automotive Grade Linux (AGL) x64 platforms](https://github.com/LuxoftAKutsan/sdl_evolution/blob/port_sdl_on_qnx700_and_agl/proposals/nnnn-sdl_on_qnx700_agl.md)

### Summary
Unit tests have been fixed for: 

- hmi_message_handler_impl_test

Commit "Fixed size stack of thread":https://github.com/Ford-Luxoft/sdl_core/pull/34/commits/74663f321d40909deb3b4cea9d660e4cab27b183 
_corrected stack size of a thread, which is then used as params  for the pthread_attr_setstacksize in Thread::start function.
We are using more than 4K memory for running a test, but set less than 1K.
For the correct work 6K is sufficient, but I set 8K because of precaution._

Commit "Fixed logic of work using boost conditional variable":https://github.com/Ford-Luxoft/sdl_core/pull/34/commits/052292834a23b84d938f226e6884c483b72ce2ec & https://github.com/Ford-Luxoft/sdl_core/pull/34/commits/511a9ffa901613d55d8e31c805d80669274d0ac1
_implement it:_ 
_Note that the same mutex is locked before the shared data is updated, but that  mutex does not  have to be locked across the call to notify_one._:https://www.boost.org/doc/libs/1_66_0/doc/html/thread/synchronization.html#thread.synchronization.condvar_ref 

Commit "Fixed behavior of destruction for thread and delegate thread.":https://github.com/Ford-Luxoft/sdl_core/pull/34/commits/a8765c36b6b7485a9c44d10e99ad828e10c812c9
function  threads::DeleteThread(thread_) deletes thread object which is used inside "thread_delegate_ " and "join()" in ~Thread()



### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)